### PR TITLE
fix(add-listing-screen): adapt screen to types and make it scrollable

### DIFF
--- a/app/src/androidTest/java/com/android/mySwissDorm/listing/AddListingScreenTest.kt
+++ b/app/src/androidTest/java/com/android/mySwissDorm/listing/AddListingScreenTest.kt
@@ -3,9 +3,8 @@ package com.android.mySwissDorm.ui.overview
 import AddListingScreen
 import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.lifecycle.viewmodel.compose.viewModel
-import com.android.mySwissDorm.ui.listing.HousingType
-import com.android.mySwissDorm.ui.listing.ListingViewModel
+import com.android.mySwissDorm.model.rental.RoomType
+import com.android.mySwissDorm.ui.listing.AddListingViewModel
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -14,11 +13,11 @@ class AddListingScreenTest {
 
   @get:Rule val composeTestRule = createComposeRule()
 
-  private lateinit var viewModel: ListingViewModel
+  private lateinit var viewModel: AddListingViewModel
 
   @Before
   fun setup() {
-    viewModel = ListingViewModel()
+    viewModel = AddListingViewModel()
     composeTestRule.setContent { AddListingScreen(onOpenMap = {}, onConfirm = {}) }
   }
 
@@ -47,10 +46,10 @@ class AddListingScreenTest {
     composeTestRule.onNodeWithText("Housing type").performClick()
 
     // Select a housing type
-    composeTestRule.onNodeWithText(HousingType.STUDIO.label).performClick()
+    composeTestRule.onNodeWithText(RoomType.STUDIO.toString()).performClick()
 
     // Check that the selected housing type is displayed
-    composeTestRule.onNodeWithText(HousingType.STUDIO.label).assertExists()
+    composeTestRule.onNodeWithText(RoomType.STUDIO.toString()).assertExists()
   }
 
   @Test
@@ -59,7 +58,7 @@ class AddListingScreenTest {
     composeTestRule.onNodeWithText("Listing title").performTextInput("Beautiful Studio")
     composeTestRule.onNodeWithText("Location / Residency name").performTextInput("Green Apartments")
     composeTestRule.onNodeWithText("Housing type").performClick()
-    composeTestRule.onNodeWithText(HousingType.STUDIO.label).performClick()
+    composeTestRule.onNodeWithText(RoomType.STUDIO.toString()).performClick()
     composeTestRule.onNodeWithText("Room size (m²)").performTextInput("25")
 
     // Verify that the submit button is enabled
@@ -71,7 +70,7 @@ class AddListingScreenTest {
     // Simulate invalid data (e.g., empty title)
     composeTestRule.onNodeWithText("Location / Residency name").performTextInput("Green Apartments")
     composeTestRule.onNodeWithText("Housing type").performClick()
-    composeTestRule.onNodeWithText(HousingType.STUDIO.label).performClick()
+    composeTestRule.onNodeWithText(RoomType.STUDIO.toString()).performClick()
     composeTestRule.onNodeWithText("Room size (m²)").performTextInput("25")
 
     // Verify that the submit button is disabled due to missing title

--- a/app/src/main/java/com/android/mySwissDorm/model/rental/RentalListing.kt
+++ b/app/src/main/java/com/android/mySwissDorm/model/rental/RentalListing.kt
@@ -18,10 +18,14 @@ data class RentalListing(
     val status: RentalStatus
 )
 
-enum class RoomType(val toString: String) {
+enum class RoomType(val value: String) {
   STUDIO("Studio"),
   APARTMENT("Apartment"),
-  COLOCATION("Coloc"),
+  COLOCATION("Room in flatshare");
+
+  override fun toString(): String {
+    return value
+  }
 }
 
 enum class RentalStatus {

--- a/app/src/main/java/com/android/mySwissDorm/ui/listing/AddListingScreen.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/listing/AddListingScreen.kt
@@ -1,8 +1,11 @@
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.AddAPhoto
 import androidx.compose.material.icons.filled.Apartment
 import androidx.compose.material.icons.filled.ArrowBack
@@ -18,9 +21,9 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.android.mySwissDorm.ui.listing.HousingType
+import com.android.mySwissDorm.model.rental.RoomType
+import com.android.mySwissDorm.ui.listing.AddListingViewModel
 import com.android.mySwissDorm.ui.listing.ListingForm
-import com.android.mySwissDorm.ui.listing.ListingViewModel
 
 @OptIn(ExperimentalMaterial3Api::class) val coralColor: Long = 0xFFFF6666
 
@@ -32,20 +35,26 @@ fun AddListingScreen(
     onOpenMap: () -> Unit, // navigate to "drop a pin" screen
     onConfirm: (ListingForm) -> Unit // called when form valid
 ) {
-  val viewModel: ListingViewModel = viewModel()
+  val viewModel: AddListingViewModel = viewModel()
 
   // Validation and form submission moved to the ViewModel
   val isFormValid = viewModel.isFormValid
   val mapLat = viewModel.mapLat.value
   val mapLng = viewModel.mapLng.value
 
+  // Remember scroll state
+  val scrollState = rememberScrollState()
+
   Scaffold(
       topBar = {
         CenterAlignedTopAppBar(
             title = { Text("Add Listing") },
             navigationIcon = {
-              IconButton(onClick = { /* Handle Back Navigation */}) {
-                Icon(Icons.Default.ArrowBack, contentDescription = "Back", tint = accentColor)
+              IconButton(onClick = { /* TODO: Handle Back Navigation */}) {
+                Icon(
+                    Icons.AutoMirrored.Filled.ArrowBack,
+                    contentDescription = "Back",
+                    tint = accentColor)
               }
             })
       },
@@ -70,8 +79,13 @@ fun AddListingScreen(
           }
         }
       }) { padding ->
+        // Wrap the content in a vertical scrollable column
         Column(
-            modifier.fillMaxSize().padding(padding).padding(horizontal = 16.dp, vertical = 10.dp),
+            modifier
+                .fillMaxSize()
+                .padding(padding)
+                .padding(horizontal = 16.dp, vertical = 10.dp)
+                .verticalScroll(scrollState), // Make the column scrollable
             verticalArrangement = Arrangement.spacedBy(14.dp)) {
               OutlinedTextField(
                   value = viewModel.title.value,
@@ -124,7 +138,7 @@ fun AddListingScreen(
                   onSelected = { viewModel.housingType.value = it },
                   accentColor = accentColor)
 
-              if (viewModel.housingType.value == HousingType.ROOM_IN_SHARED_APT) {
+              if (viewModel.housingType.value == RoomType.COLOCATION) {
                 OutlinedTextField(
                     value = viewModel.roommates.value,
                     onValueChange = { input ->
@@ -154,6 +168,7 @@ fun AddListingScreen(
                                 Color.Gray // Optional: Change label color when not focused
                             ))
               }
+
               val isValid = viewModel.sizeSqm.value.toDoubleOrNull() != null
               OutlinedTextField(
                   value = viewModel.sizeSqm.value,
@@ -252,10 +267,6 @@ fun AddListingScreen(
                           Spacer(Modifier.width(8.dp))
                           Text("Add pictures")
                         }
-                    AssistChip(
-                        onClick = { // TODO: handle image clearing }
-                        },
-                        label = { Text("Clear") })
                   }
             }
       }
@@ -263,13 +274,9 @@ fun AddListingScreen(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun HousingTypeDropdown(
-    selected: HousingType?,
-    onSelected: (HousingType) -> Unit,
-    accentColor: Color
-) {
+fun HousingTypeDropdown(selected: RoomType?, onSelected: (RoomType) -> Unit, accentColor: Color) {
   var expanded by remember { mutableStateOf(false) }
-  val label = selected?.label ?: "Select housing type"
+  val label = selected?.toString() ?: "Select housing type"
 
   ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }) {
     OutlinedTextField(
@@ -290,9 +297,9 @@ fun HousingTypeDropdown(
         modifier = Modifier.menuAnchor().fillMaxWidth(),
     )
     ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-      HousingType.values().forEach { type ->
+      RoomType.entries.forEach { type ->
         DropdownMenuItem(
-            text = { Text(type.label) },
+            text = { Text(type.toString()) },
             onClick = {
               onSelected(type)
               expanded = false

--- a/app/src/main/java/com/android/mySwissDorm/ui/listing/AddListingViewModel.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/listing/AddListingViewModel.kt
@@ -3,12 +3,13 @@ package com.android.mySwissDorm.ui.listing
 import android.net.Uri
 import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
+import com.android.mySwissDorm.model.rental.RoomType
 
-class ListingViewModel : ViewModel() {
+class AddListingViewModel : ViewModel() {
   // Mutable state for form fields
   var title = mutableStateOf("")
   var residency = mutableStateOf("")
-  var housingType = mutableStateOf<HousingType?>(null)
+  var housingType = mutableStateOf<RoomType?>(null)
   var roommates = mutableStateOf("")
   var sizeSqm = mutableStateOf("")
   var description = mutableStateOf("")
@@ -21,7 +22,7 @@ class ListingViewModel : ViewModel() {
     get() {
       val sizeOk = sizeSqm.value.toDoubleOrNull()?.let { it in 1.0..1000.0 } == true
       val roommatesOk =
-          if (housingType.value == HousingType.ROOM_IN_SHARED_APT) {
+          if (housingType.value == RoomType.COLOCATION) {
             roommates.value.toIntOrNull()?.let { it in 1..20 } == true
           } else {
             true

--- a/app/src/main/java/com/android/mySwissDorm/ui/listing/HousingType.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/listing/HousingType.kt
@@ -1,9 +1,0 @@
-package com.android.mySwissDorm.ui.listing
-
-enum class HousingType(val label: String) {
-  ROOM_IN_SHARED_APT("Room in a shared apartment"),
-  STUDIO("Studio"),
-  INDEPENDENT_ROOM("Independent room"),
-  APARTMENT("Apartment"),
-  HOUSE("House")
-}

--- a/app/src/main/java/com/android/mySwissDorm/ui/listing/ListingForm.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/listing/ListingForm.kt
@@ -1,11 +1,12 @@
 package com.android.mySwissDorm.ui.listing
 
 import android.net.Uri
+import com.android.mySwissDorm.model.rental.RoomType
 
 data class ListingForm(
     val title: String,
     val residencyName: String,
-    val housingType: HousingType?,
+    val housingType: RoomType?,
     val roommates: Int?, // only when shared apartment
     val roomSizeSqm: Double?, // m²
     val description: String,

--- a/app/src/main/java/com/android/mySwissDorm/ui/listing/ViewListingScreen.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/listing/ViewListingScreen.kt
@@ -93,7 +93,7 @@ fun ViewListingScreen(
                   modifier = Modifier.fillMaxWidth().background(Color.Gray).padding(16.dp),
                   verticalArrangement = Arrangement.spacedBy(12.dp)) {
                     // Add other UI components here
-                    BulletPointText(text = listing.roomType.toString)
+                    BulletPointText(text = listing.roomType.toString())
                     BulletPointText(text = "${listing.pricePerMonth} .-/month")
                     BulletPointText(text = "${listing.areaInM2} m²")
                     BulletPointText(text = "Starting ${formatTimestamp(listing.startDate)}")

--- a/app/src/main/java/com/android/mySwissDorm/ui/theme/Type.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/theme/Type.kt
@@ -2,11 +2,9 @@ package com.android.mySwissDorm.ui.theme
 
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
-import com.android.mySwissDorm.R
 
 // Set of Material typography styles to start with
 val Typography =
@@ -20,7 +18,7 @@ val Typography =
                 letterSpacing = 0.5.sp),
         titleLarge =
             TextStyle(
-                fontFamily = FontFamily(Font(R.font.lexend_giga_bold)),
+                fontFamily = FontFamily.Default,
                 fontWeight = FontWeight.Normal,
                 fontSize = 32.sp,
                 lineHeight = 28.sp,


### PR DESCRIPTION

-delete HouseTypes file and used the RoomType enum in RentalListing.kt 
-adapt AddListingScreen.kt, its ViewModel, and its tests to these changes 
-adapt the ListingForm.kt and ViewListingScreen.kt to it too 
-rename ListingViewModel.kt to AddListingViewModel.kt for convenience