### PR TITLE
fix(navigation): Resolve the issue where the user cannot sign in again

### DIFF
--- a/app/src/main/java/com/android/mySwissDorm/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/navigation/NavigationActions.kt
@@ -19,7 +19,9 @@ class NavigationActions(private val navController: NavHostController) {
     if (screen.isTopLevelDestination && current == screen.route) return
 
     navController.navigate(screen.route) {
-      if (screen.isTopLevelDestination) {
+      if (screen == Screen.SignIn) {
+        popUpTo(0) { inclusive = true }
+      } else if (screen.isTopLevelDestination) {
         // Top-level: single top, restore state, pop up to graph start
         launchSingleTop = true
         restoreState = true


### PR DESCRIPTION
## Summary
When a user launch the application and start at the Homepage (already logged), if they logout and then try to sign in, they remain blocked at the sign in page.
## Actual fix
This happen because when `navController.navigate(Screen.SignIn)` is executed, `navController.graph.findStartDestination().id` gives the Home page id, and since `launchingSingleTop` is `true`, the navigation does not occur since the Home page id is already on top.

This can be fixed by pop everything when sign-out.