### PR TITLE
feat(nav): wire add listing confirmation button to navigation

### DIFF
--- a/app/src/main/java/com/android/mySwissDorm/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/navigation/AppNavHost.kt
@@ -85,7 +85,14 @@ fun AppNavHost(
       AddListingScreen(
           onOpenMap = { Toast.makeText(context, "Not implemented yet", Toast.LENGTH_SHORT).show() },
           onBack = { navActions.goBack() },
-          onConfirm = { Toast.makeText(context, "Not implemented yet", Toast.LENGTH_SHORT).show() })
+          onConfirm = { created ->
+            navController.navigate(Screen.ListingOverview(created.uid).route) {
+              // Remove AddListing so back from overview goes to whatever was before it (Homepage
+              // here)
+              popUpTo(Screen.AddListing.route) { inclusive = true }
+              launchSingleTop = true
+            }
+          })
     }
 
     composable(Screen.CityOverview.route) { navBackStackEntry ->


### PR DESCRIPTION
the confirm listing button on the AddListingScreen has been wired to redirect to the listing overview screen so that the user can see their listing after it's posted.
The AddListing screen is popped out of the back stack so that pressing back on the ListingOverviewScreen does not take you back to the AddListingScreen form, but to the homepage