### PR TITLE
fix(view user profile test): add waiting time for loading

### DIFF
--- a/app/src/androidTest/java/com/android/mySwissDorm/ui/profile/ViewUserProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/mySwissDorm/ui/profile/ViewUserProfileScreenTest.kt
@@ -115,8 +115,10 @@ class ViewUserProfileScreenTest : FirestoreTest() {
 
     // Retry should now load successfully
     compose.onNodeWithTag(T.RETRY_BTN).performClick()
-
-    compose.waitUntil(10_000) {
+    compose.waitUntil(5000) {
+      compose.onAllNodesWithTag(T.RETRY_BTN, useUnmergedTree = true).fetchSemanticsNodes().isEmpty()
+    }
+    compose.waitUntil(5000) {
       compose.onAllNodesWithTag(T.TITLE, useUnmergedTree = true).fetchSemanticsNodes().isNotEmpty()
     }
     compose.onNodeWithTag(T.TITLE).assertIsDisplayed()


### PR DESCRIPTION
Fix the view user profile screen test  by adding a waiting time for the loading since we didn't give it enough time to load before performing another action. (minor change)