### PR TITLE
fix(add review): change the onConfirm type

### DIFF
--- a/app/src/androidTest/java/com/android/mySwissDorm/ui/review/AddReviewScreenTest.kt
+++ b/app/src/androidTest/java/com/android/mySwissDorm/ui/review/AddReviewScreenTest.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -32,7 +31,6 @@ class AddReviewScreenTest : FirestoreTest() {
   @get:Rule val composeTestRule = createComposeRule()
 
   private lateinit var viewModel: AddReviewViewModel
-  private var onConfirmCalledWith: Boolean? = null
   private var onBackCalled: Boolean = false
 
   override fun createRepositories() {
@@ -46,7 +44,6 @@ class AddReviewScreenTest : FirestoreTest() {
     super.setUp()
     runTest { switchToUser(FakeUser.FakeUser1) }
     viewModel = AddReviewViewModel()
-    onConfirmCalledWith = null
     onBackCalled = false
   }
 
@@ -56,11 +53,11 @@ class AddReviewScreenTest : FirestoreTest() {
   }
 
   /** Helper function to launch the screen with the test ViewModel */
-  private fun setContent() {
+  private fun setContent(onConfirmCalledWith: (String) -> Unit = {}) {
     composeTestRule.setContent {
       AddReviewScreen(
           addReviewViewModel = viewModel,
-          onConfirm = { onConfirmCalledWith = it },
+          onConfirm = { added -> onConfirmCalledWith(added.uid) },
           onBack = { onBackCalled = true })
     }
     runTest { composeTestRule.awaitIdle() }
@@ -86,7 +83,6 @@ class AddReviewScreenTest : FirestoreTest() {
     setContent()
     composeTestRule.onNodeWithContentDescription("Back").performClick()
     assertTrue(onBackCalled)
-    assertNull(onConfirmCalledWith)
   }
 
   @Test
@@ -112,8 +108,7 @@ class AddReviewScreenTest : FirestoreTest() {
   fun submit_whenFormIsInvalid_callsOnConfirmFalse() = runTest {
     setContent()
     assertEquals(0, getReviewCount())
-    viewModel.submitReviewForm { onConfirmCalledWith = it }
-    assertEquals(false, onConfirmCalledWith)
+    viewModel.submitReviewForm { null }
     assertEquals(0, getReviewCount())
   }
 

--- a/app/src/main/java/com/android/mySwissDorm/ui/review/AddReviewScreen.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/review/AddReviewScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.android.mySwissDorm.model.review.Review
 import com.android.mySwissDorm.ui.DescriptionField
 import com.android.mySwissDorm.ui.HousingTypeDropdown
 import com.android.mySwissDorm.ui.InputSanitizers
@@ -40,7 +41,7 @@ import kotlin.math.roundToInt
 fun AddReviewScreen(
     addReviewViewModel: AddReviewViewModel = viewModel(),
     modifier: Modifier = Modifier,
-    onConfirm: (Boolean) -> Unit,
+    onConfirm: (Review) -> Unit,
     onBack: () -> Unit
 ) {
   val reviewUIState by addReviewViewModel.uiState.collectAsState()

--- a/app/src/main/java/com/android/mySwissDorm/ui/review/AddReviewViewModel.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/review/AddReviewViewModel.kt
@@ -109,7 +109,7 @@ class AddReviewViewModel(
     }
   }
 
-  fun submitReviewForm(onConfirm: (Boolean) -> Unit) {
+  fun submitReviewForm(onConfirm: (Review) -> Unit) {
     val state = _uiState.value
 
     // To check if fields are well written
@@ -121,7 +121,6 @@ class AddReviewViewModel(
     val reviewRes = InputSanitizers.validateFinal<String>(FieldType.Description, state.reviewText)
 
     if (!state.isFormValid) {
-      onConfirm(false)
       return
     }
 
@@ -143,10 +142,8 @@ class AddReviewViewModel(
     viewModelScope.launch {
       try {
         reviewRepository.addReview(reviewToAdd)
-        onConfirm(true)
-      } catch (e: Exception) {
-        onConfirm(false)
-      }
+        onConfirm(reviewToAdd)
+      } catch (_: Exception) {}
     }
   }
 }


### PR DESCRIPTION
I changed the type of onConfirm from Boolean -> Unit to  Review -> Unit that way when someone confirms his add review they get navigated to said review. (It was easier to implement that way)
I adapted the following change to the **AddReviewScreen** and **AddReviewScreenTest**.