### PR TITLE
fix : Fix dark mode on log in screen

### DIFF
--- a/app/src/main/java/com/android/mySwissDorm/MainActivity.kt
+++ b/app/src/main/java/com/android/mySwissDorm/MainActivity.kt
@@ -1,7 +1,6 @@
 package com.android.mySwissDorm
 
 import android.content.Context
-import android.content.SharedPreferences
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
@@ -32,7 +31,7 @@ class MainActivity : ComponentActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    
+
     // Initialize theme preference synchronously from SharedPreferences BEFORE setContent
     // This ensures the theme is correct from the very first render, including login screen
     // Always load from SharedPreferences - this persists even after logout
@@ -40,7 +39,7 @@ class MainActivity : ComponentActivity() {
     // Set the preference in global state - this will be used by the theme composable
     // If savedPreference is null, we leave it null to follow system theme
     ThemePreferenceState.updatePreference(savedPreference)
-    
+
     Log.d("", Screen.topLevel.joinToString { it.name })
     setContent {
       PhotoRepositoryProvider.initialize(LocalContext.current)

--- a/app/src/main/java/com/android/mySwissDorm/ui/theme/Theme.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/theme/Theme.kt
@@ -5,9 +5,9 @@ import android.app.Activity
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
@@ -62,13 +62,11 @@ private val DarkColors =
 @Composable
 fun MySwissDormAppTheme(content: @Composable () -> Unit) {
   val context = LocalContext.current
-  
+
   // Load preference synchronously from SharedPreferences as fallback
   // MainActivity should have already set it in ThemePreferenceState, but this is a safety net
-  val savedPreference = remember {
-    ThemePreferenceManager.getLocalPreferenceSync(context)
-  }
-  
+  val savedPreference = remember { ThemePreferenceManager.getLocalPreferenceSync(context) }
+
   // Ensure global state is initialized from saved preference if it's null
   // This is a fallback in case MainActivity initialization didn't work
   // Use SideEffect since we're performing a side effect (updating state), not remembering a value
@@ -79,10 +77,10 @@ fun MySwissDormAppTheme(content: @Composable () -> Unit) {
       ThemePreferenceState.updatePreference(savedPreference)
     }
   }
-  
+
   // Observe the global state - this will trigger recomposition when it changes
   val globalPreference by ThemePreferenceState.darkModePreference
-  
+
   // Use global preference (set by MainActivity or fallback), or savedPreference as last resort
   // MainActivity should have already set globalPreference, so this should use that
   val userPreference = globalPreference ?: savedPreference
@@ -91,11 +89,12 @@ fun MySwissDormAppTheme(content: @Composable () -> Unit) {
   // CRITICAL: Use user preference ONLY if it's explicitly set (true or false)
   // If userPreference is null (no preference saved), ALWAYS follow system theme
   // This ensures the login screen follows the phone's theme when no preference is set
-  val darkTheme = when (userPreference) {
-    true -> true  // User explicitly wants dark mode
-    false -> false // User explicitly wants light mode
-    null -> systemDarkTheme // No preference set - MUST follow system theme (phone's theme)
-  }
+  val darkTheme =
+      when (userPreference) {
+        true -> true // User explicitly wants dark mode
+        false -> false // User explicitly wants light mode
+        null -> systemDarkTheme // No preference set - MUST follow system theme (phone's theme)
+      }
   val colorScheme = if (darkTheme) DarkColors else LightColors
 
   val view = LocalView.current

--- a/app/src/main/java/com/android/mySwissDorm/ui/theme/ThemePreferenceManager.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/theme/ThemePreferenceManager.kt
@@ -102,8 +102,8 @@ class ThemePreferenceManager(
   }
 
   /**
-   * Retrieves the preference from local SharedPreferences storage synchronously.
-   * This is a static helper that can be called before Compose initialization.
+   * Retrieves the preference from local SharedPreferences storage synchronously. This is a static
+   * helper that can be called before Compose initialization.
    *
    * @param context The Android context
    * @return The stored preference, or null if not set
@@ -113,8 +113,8 @@ class ThemePreferenceManager(
     const val KEY_DARK_MODE = "dark_mode_enabled"
 
     /**
-     * Gets the local dark mode preference from SharedPreferences synchronously.
-     * This can be called before Compose initialization.
+     * Gets the local dark mode preference from SharedPreferences synchronously. This can be called
+     * before Compose initialization.
      */
     fun getLocalPreferenceSync(context: Context): Boolean? {
       val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
@@ -141,10 +141,10 @@ class ThemePreferenceManager(
     // ALWAYS save to SharedPreferences first - this ensures the preference persists
     // even when the user is logged out
     setLocalPreference(enabled)
-    
+
     // Update the shared state immediately so the UI reflects the change
     ThemePreferenceState.updatePreference(enabled)
-    
+
     // Optionally sync to Firebase if user is logged in (for cross-device sync)
     val user = auth.currentUser
     if (user != null) {
@@ -191,7 +191,7 @@ class ThemePreferenceManager(
    *
    * Should be called when the app starts or when the theme preference manager is created. Loads the
    * preference from Firebase or SharedPreferences and updates the shared state.
-   * 
+   *
    * Only updates if the current state is null (not already initialized from SharedPreferences).
    */
   suspend fun initializeState() {
@@ -208,7 +208,8 @@ class ThemePreferenceManager(
           val profile = profileRepository.getProfile(user.uid)
           val firebasePreference = profile.userSettings.darkMode
           // Only update if Firebase has a different value
-          if (firebasePreference != null && firebasePreference != ThemePreferenceState.darkModePreference.value) {
+          if (firebasePreference != null &&
+              firebasePreference != ThemePreferenceState.darkModePreference.value) {
             ThemePreferenceState.updatePreference(firebasePreference)
           }
         } catch (e: Exception) {
@@ -217,7 +218,6 @@ class ThemePreferenceManager(
       }
     }
   }
-
 }
 
 /**
@@ -248,9 +248,7 @@ fun rememberThemePreferenceManager(): ThemePreferenceManager {
 
   // Then update from Firebase asynchronously if user is logged in
   // This will only update if Firebase has a different value
-  LaunchedEffect(Unit) {
-    manager.initializeState()
-  }
+  LaunchedEffect(Unit) { manager.initializeState() }
 
   return manager
 }
@@ -273,7 +271,7 @@ fun rememberThemePreferenceManager(): ThemePreferenceManager {
 fun rememberDarkModePreference(): Pair<Boolean?, (Boolean?) -> Unit> {
   val context = LocalContext.current
   val manager = rememberThemePreferenceManager()
-  
+
   // Ensure preference is initialized synchronously during composition
   // This must happen before we read the state to ensure correct theme on first render
   SideEffect {
@@ -284,7 +282,7 @@ fun rememberDarkModePreference(): Pair<Boolean?, (Boolean?) -> Unit> {
       }
     }
   }
-  
+
   // Read the state using 'by' to properly observe it and trigger recomposition
   val preference by ThemePreferenceState.darkModePreference
 


### PR DESCRIPTION
Login screen was following the system's mode and thus when you log in the app follows the system's mode until you enter settings where it switches back automatically to the user's preferred saved mode.

Now the mode is saved locally so that even when logged out, when the user opens the app, the login screen and every screen that follows follow the last saved theme.