### PR TITLE
refactor: use `DefaultAddPhotoButton` in new screens

### DIFF
--- a/app/src/main/java/com/android/mySwissDorm/ui/listing/EditListingScreen.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/listing/EditListingScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.AddAPhoto
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -17,6 +16,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.android.mySwissDorm.resources.C
+import com.android.mySwissDorm.ui.DefaultAddPhotoButton
 import com.android.mySwissDorm.ui.DescriptionField
 import com.android.mySwissDorm.ui.HousingTypeDropdown
 import com.android.mySwissDorm.ui.InputSanitizers
@@ -247,20 +247,8 @@ fun EditListingScreen(
               Row(
                   verticalAlignment = Alignment.CenterVertically,
                   horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                    FilledTonalButton(
-                        onClick = { /* TODO: implement image selection */},
-                        colors =
-                            ButtonDefaults.buttonColors(
-                                containerColor = TextBoxColor,
-                                contentColor = MainColor,
-                                disabledContentColor = TextBoxColor,
-                                disabledContainerColor = TextBoxColor),
-                        shape = RoundedCornerShape(14.dp)) {
-                          Icon(Icons.Default.AddAPhoto, null, tint = MainColor)
-                          Spacer(Modifier.width(8.dp))
-                          Text("Add pictures")
-                        }
-                  }
+                    DefaultAddPhotoButton(onSelectPhoto = {}) // TODO display the photo
+              }
             }
 
         // Date Picker Dialog

--- a/app/src/main/java/com/android/mySwissDorm/ui/review/EditReviewScreen.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/review/EditReviewScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.AddAPhoto
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -16,6 +15,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.android.mySwissDorm.ui.DefaultAddPhotoButton
 import com.android.mySwissDorm.ui.DescriptionField
 import com.android.mySwissDorm.ui.HousingTypeDropdown
 import com.android.mySwissDorm.ui.InputSanitizers
@@ -233,17 +233,8 @@ fun EditReviewScreen(
               Row(
                   verticalAlignment = Alignment.CenterVertically,
                   horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-                    FilledTonalButton(
-                        onClick = { /* not yet implemented */},
-                        colors =
-                            ButtonDefaults.filledTonalButtonColors(
-                                containerColor = TextBoxColor, contentColor = MainColor),
-                        shape = RoundedCornerShape(14.dp)) {
-                          Icon(Icons.Default.AddAPhoto, null, tint = MainColor)
-                          Spacer(Modifier.width(8.dp))
-                          Text("Add pictures")
-                        }
-                  }
+                    DefaultAddPhotoButton(onSelectPhoto = {}) // TODO display the photo
+              }
             }
       }
 }


### PR DESCRIPTION
This PR updates `EditReviewScreen` and `EditListingScreen` to make them use the `DefaultAddPhotoButton`, i.e. replaced the previous non-functionnal buttons with the `DefaultAddPhotoButton`.