### PR TITLE
fix: review deletion crash and add confirmation dialog

### DIFF
--- a/app/src/main/java/com/android/mySwissDorm/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/navigation/AppNavHost.kt
@@ -322,8 +322,30 @@ fun AppNavHost(
             Toast.makeText(context, "Review saved", Toast.LENGTH_SHORT).show()
           },
           onDelete = { residencyName ->
-            navActions.navigateTo(Screen.ReviewsByResidencyOverview(residencyName))
+            // Pop EditReview from backstack
             navController.popBackStack(Screen.EditReview.route, inclusive = true)
+
+            // Check if we're now on ReviewOverview and pop it too (since the review is deleted)
+            var currentRoute = navController.currentDestination?.route
+            if (currentRoute?.startsWith("reviewOverview/") == true) {
+              navController.popBackStack()
+              // Update currentRoute after popping ReviewOverview
+              currentRoute = navController.currentDestination?.route
+            }
+
+            // Navigate back based on where we are now
+            // If we're already at ReviewsByResidencyOverview or ProfileContributions, stay there
+            // Otherwise, navigate to ReviewsByResidencyOverview (using residencyName) or fallback
+            // to ProfileContributions
+            if (currentRoute?.startsWith("reviewsByResidencyOverview/") != true &&
+                currentRoute != Screen.ProfileContributions.route) {
+              try {
+                navActions.navigateTo(Screen.ReviewsByResidencyOverview(residencyName))
+              } catch (e: Exception) {
+                // If navigation fails, try ProfileContributions as fallback
+                navActions.navigateTo(Screen.ProfileContributions)
+              }
+            }
             Toast.makeText(context, "Review deleted", Toast.LENGTH_SHORT).show()
           })
     }

--- a/app/src/main/java/com/android/mySwissDorm/ui/review/EditReviewScreen.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/review/EditReviewScreen.kt
@@ -73,6 +73,7 @@ fun EditReviewScreen(
 ) {
   val editReviewUIState by editReviewViewModel.uiState.collectAsState()
   val scrollState = rememberScrollState()
+  var showDeleteConfirm by remember { mutableStateOf(false) }
 
   Scaffold(
       topBar = {
@@ -88,10 +89,7 @@ fun EditReviewScreen(
             },
             actions = {
               IconButton(
-                  onClick = {
-                    editReviewViewModel.deleteReview(reviewID)
-                    onDelete(editReviewUIState.residencyName)
-                  },
+                  onClick = { showDeleteConfirm = true },
                   modifier = Modifier.testTag("deleteButton") // ← add this
                   ) {
                     Icon(Icons.Default.Delete, contentDescription = "Delete", tint = MainColor)
@@ -238,4 +236,28 @@ fun EditReviewScreen(
               }
             }
       }
+
+  if (showDeleteConfirm) {
+    AlertDialog(
+        onDismissRequest = { showDeleteConfirm = false },
+        title = { Text("Delete review?", color = TextColor) },
+        text = {
+          Text(
+              "This will permanently delete your review. This action cannot be undone.",
+              color = TextColor)
+        },
+        confirmButton = {
+          TextButton(
+              onClick = {
+                showDeleteConfirm = false
+                editReviewViewModel.deleteReview(reviewID)
+                onDelete(editReviewUIState.residencyName)
+              }) {
+                Text("Delete", color = MainColor)
+              }
+        },
+        dismissButton = {
+          TextButton(onClick = { showDeleteConfirm = false }) { Text("Cancel", color = TextColor) }
+        })
+  }
 }


### PR DESCRIPTION
This pull request significantly improves the delete review workflow in the Edit Review feature, both in the UI and its test coverage. The changes introduce a confirmation dialog before deletion, enhance navigation logic after deletion, and add robust UI tests to verify the new behavior.

**UI/UX Improvements:**

- Added a confirmation dialog to the `EditReviewScreen` that appears when the delete button is pressed, preventing accidental deletions. The dialog includes "Delete" and "Cancel" options. The actual deletion only occurs after confirmation. 

**Navigation Logic Enhancements:**

- Updated the navigation flow after a review is deleted to ensure the user is returned to the appropriate screen, handling various backstack scenarios and providing a fallback to the profile contributions screen if needed.

**Test Coverage Improvements:**

- Added comprehensive UI tests for the delete review workflow, including:
  - Verifying that the confirmation dialog appears when the delete button is pressed.
  - Ensuring that cancelling the dialog does not delete the review.
  - Confirming that accepting the dialog deletes the review and emits the correct residency name.
  - Improved test robustness by handling both merged and unmerged Compose trees and using more reliable node queries. 

These changes make the delete operation safer for users and ensure the UI behaves correctly in all scenarios.

This PR is done with the help/suggestions of AI