### PR TITLE
fix(map screen):change postion of navigation button in map

### DIFF
--- a/app/src/main/java/com/android/mySwissDorm/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/map/MapScreen.kt
@@ -64,6 +64,7 @@ fun MapScreen(
               }
             })
       },
+      floatingActionButtonPosition = FabPosition.Start,
       floatingActionButton = {
         FloatingActionButton(
             onClick = {


### PR DESCRIPTION
Thats a tiny change. In the coach's feedback for the M2 they said that the "navigation" button and the zoom out button are overlapping in the Map screen which makes it difficult for a user to use the full functionalities of the map. Here's a picture of the map after the changement.

<img width="200" height="500" alt="image" src="https://github.com/user-attachments/assets/3163ac92-0eeb-4e93-b46b-ffc20064c33e" />

This closes #162 
