### PR TITLE
build(apk with stream key): added stream key to build-apk worflow

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Just modified the build-apk workflow so it adapts to the new API we're using for the chats in our app. I simply created a github secret STREAM_API_KEY with it's correct value then used it the workflow to make sure the apk built can properly use the Stream api.