### PR TITLE
fix: Remove the hard coded image id for cities

### DIFF
--- a/app/src/androidTest/java/com/android/mySwissDorm/model/city/CitiesRepositoryFirestoreTest.kt
+++ b/app/src/androidTest/java/com/android/mySwissDorm/model/city/CitiesRepositoryFirestoreTest.kt
@@ -29,7 +29,7 @@ class CitiesRepositoryFirestoreTest : FirestoreTest() {
             name = "Lausanne",
             description = "Description of Lausanne",
             location = Location("Lausanne", 1.0, 2.0),
-            imageId = 0)
+            imageId = "")
     repo.addCity(cityToAdd)
     val returnedCity = repo.getCity("Lausanne")
     assertEquals(cityToAdd, returnedCity)
@@ -43,13 +43,13 @@ class CitiesRepositoryFirestoreTest : FirestoreTest() {
             name = "Lausanne",
             description = "Description of Lausanne",
             location = Location("Lausanne", 1.0, 2.0),
-            imageId = 0)
+            imageId = "")
     val city2 =
         City(
             name = "Geneva",
             description = "Description of Geneva",
             location = Location("Geneva", 2.0, 1.0),
-            imageId = 1)
+            imageId = "")
     val allCitiesToAdd = listOf(city1, city2)
     allCitiesToAdd.forEach { repo.addCity(it) }
     assertEquals(allCitiesToAdd.toSet(), repo.getAllCities().toSet())

--- a/app/src/androidTest/java/com/android/mySwissDorm/ui/homepage/HomePageScreenTest.kt
+++ b/app/src/androidTest/java/com/android/mySwissDorm/ui/homepage/HomePageScreenTest.kt
@@ -10,25 +10,29 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.performTextInput
-import com.android.mySwissDorm.R
 import com.android.mySwissDorm.model.city.CitiesRepositoryFirestore
 import com.android.mySwissDorm.model.city.CitiesRepositoryProvider
 import com.android.mySwissDorm.model.city.City
 import com.android.mySwissDorm.model.map.Location
 import com.android.mySwissDorm.model.map.LocationRepository
+import com.android.mySwissDorm.model.photo.PhotoRepositoryCloud
 import com.android.mySwissDorm.model.profile.ProfileRepositoryFirestore
 import com.android.mySwissDorm.model.profile.ProfileRepositoryProvider
 import com.android.mySwissDorm.resources.C
 import com.android.mySwissDorm.utils.FakeUser
 import com.android.mySwissDorm.utils.FirebaseEmulator
 import com.android.mySwissDorm.utils.FirestoreTest
+import io.mockk.unmockkAll
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 
 class HomePageScreenTest : FirestoreTest() {
 
@@ -51,25 +55,25 @@ class HomePageScreenTest : FirestoreTest() {
             description =
                 "Lausanne is a city located on Lake Geneva, known for its universities and the Olympic Museum.",
             location = Location(name = "Lausanne", latitude = 46.5197, longitude = 6.6323),
-            imageId = R.drawable.lausanne)
+            imageId = "lausanne.png")
     val cityGeneva =
         City(
             name = "Geneva",
             description = "Geneva is a global city, hosting numerous international organizations.",
             location = Location(name = "Geneva", latitude = 46.2044, longitude = 6.1432),
-            imageId = R.drawable.geneve)
+            imageId = "geneva.png")
     val cityZurich =
         City(
             name = "Zurich",
             description = "Zurich is the largest city in Switzerland and a major financial hub.",
             location = Location(name = "Zürich", latitude = 47.3769, longitude = 8.5417),
-            imageId = R.drawable.zurich)
+            imageId = "zurich.png")
     val cityFribourg =
         City(
             name = "Fribourg",
             description = "Fribourg is a bilingual city famous for its medieval architecture.",
             location = Location(name = "Fribourg", latitude = 46.8065, longitude = 7.16197),
-            imageId = R.drawable.fribourg)
+            imageId = "fribourg.png")
 
     val cities = listOf(cityLausanne, cityGeneva, cityZurich, cityFribourg)
     runTest {
@@ -90,12 +94,26 @@ class HomePageScreenTest : FirestoreTest() {
             return null
           }
         }
+    val photoRepositoryCloud: PhotoRepositoryCloud = mock()
+    runBlocking {
+      whenever(photoRepositoryCloud.retrievePhoto("fribourg.png")).thenReturn(photo)
+      whenever(photoRepositoryCloud.retrievePhoto("lausanne.png")).thenReturn(photo)
+      whenever(photoRepositoryCloud.retrievePhoto("geneva.png")).thenReturn(photo)
+      whenever(photoRepositoryCloud.retrievePhoto("zurich.png")).thenReturn(photo)
+    }
     viewModel =
         HomePageViewModel(
             citiesRepository = CitiesRepositoryProvider.repository,
             locationRepository = mockLocationRepository,
             profileRepository = ProfileRepositoryProvider.repository,
-            auth = FirebaseEmulator.auth)
+            auth = FirebaseEmulator.auth,
+            photoRepositoryCloud = photoRepositoryCloud)
+  }
+
+  @After
+  override fun tearDown() {
+    unmockkAll()
+    super.tearDown()
   }
 
   @Test

--- a/app/src/androidTest/java/com/android/mySwissDorm/utils/FirestoreTest.kt
+++ b/app/src/androidTest/java/com/android/mySwissDorm/utils/FirestoreTest.kt
@@ -322,25 +322,25 @@ abstract class FirestoreTest : TestCase() {
           description =
               "Lausanne is a city located on Lake Geneva, known for its universities and the Olympic Museum.",
           location = Location(name = "Lausanne", latitude = 46.5197, longitude = 6.6323),
-          imageId = R.drawable.lausanne)
+          imageId = "lausanne.png")
   val cityGeneva =
       City(
           name = "Geneva",
           description = "Geneva is a global city, hosting numerous international organizations.",
           location = Location(name = "Geneva", latitude = 46.2044, longitude = 6.1432),
-          imageId = R.drawable.geneve)
+          imageId = "geneva.png")
   val cityZurich =
       City(
           name = "Zurich",
           description = "Zurich is the largest city in Switzerland and a major financial hub.",
           location = Location(name = "Zürich", latitude = 47.3769, longitude = 8.5417),
-          imageId = R.drawable.zurich)
+          imageId = "zurich.png")
   val cityFribourg =
       City(
           name = "Fribourg",
           description = "Fribourg is a bilingual city famous for its medieval architecture.",
           location = Location(name = "Fribourg", latitude = 46.8065, longitude = 7.16197),
-          imageId = R.drawable.fribourg)
+          imageId = "fribourg.png")
 
   val cities = listOf(cityLausanne, cityGeneva, cityZurich, cityFribourg)
 

--- a/app/src/main/java/com/android/mySwissDorm/model/city/CitiesRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/mySwissDorm/model/city/CitiesRepositoryFirestore.kt
@@ -51,7 +51,7 @@ class CitiesRepositoryFirestore(private val db: FirebaseFirestore) : CitiesRepos
                 latitude = it["latitude"] as? Double ?: return null,
                 longitude = it["longitude"] as? Double ?: return null)
           } ?: return null
-      val imageId = document.getLong("imageId")?.toInt() ?: return null
+      val imageId = document.get("imageId") as? String ?: return null
 
       City(name = name, description = description, location = location, imageId = imageId)
     } catch (e: Exception) {

--- a/app/src/main/java/com/android/mySwissDorm/model/city/City.kt
+++ b/app/src/main/java/com/android/mySwissDorm/model/city/City.kt
@@ -6,5 +6,5 @@ data class City(
     val name: String,
     val description: String,
     val location: Location,
-    val imageId: Int
+    val imageId: String
 )

--- a/app/src/main/java/com/android/mySwissDorm/model/photo/PhotoRepositoryStorage.kt
+++ b/app/src/main/java/com/android/mySwissDorm/model/photo/PhotoRepositoryStorage.kt
@@ -11,13 +11,24 @@ import kotlinx.coroutines.tasks.await
 /** The directory in which the photo are stored in storage */
 const val DIR = "photos"
 
-/** This is an implementation of a [PhotoRepositoryCloud] using the storage service of Firebase. */
+/**
+ * This is an implementation of a [PhotoRepositoryCloud] using the storage service of Firebase.
+ *
+ * @param photoSubDir this specify in which subdirectory the operations should be done. This must
+ *   respect this format: "path/to/subdirectory/"
+ */
 class PhotoRepositoryStorage(
     storageRef: StorageReference = Firebase.storage.reference,
-    localRepository: PhotoRepository = PhotoRepositoryProvider.local_repository
+    localRepository: PhotoRepository = PhotoRepositoryProvider.local_repository,
+    photoSubDir: String = ""
 ) : PhotoRepositoryCloud(localRepository) {
 
-  private val dirRef = storageRef.child("$DIR/")
+  init {
+    require(photoSubDir.firstOrNull()?.isLetter() ?: true)
+    require(photoSubDir.isEmpty() || photoSubDir.last() == '/')
+  }
+
+  private val dirRef = storageRef.child("$DIR/$photoSubDir")
 
   override suspend fun retrievePhoto(uid: String): Photo {
     try {

--- a/app/src/main/java/com/android/mySwissDorm/ui/admin/AdminPageViewModel.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/admin/AdminPageViewModel.kt
@@ -236,7 +236,7 @@ class AdminPageViewModel(
                     name = uiState.name.trim(),
                     description = uiState.description.trim(),
                     location = location,
-                    imageId = uiState.imageId.trim().toIntOrNull() ?: 0)
+                    imageId = uiState.imageId)
             citiesRepo.addCity(city)
           }
           EntityType.RESIDENCY -> {

--- a/app/src/main/java/com/android/mySwissDorm/ui/homepage/HomePageScreen.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/homepage/HomePageScreen.kt
@@ -1,7 +1,7 @@
 package com.android.mySwissDorm.ui.homepage
 
+import android.net.Uri
 import android.widget.Toast
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -40,13 +40,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.credentials.CredentialManager
 import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.AsyncImage
 import com.android.mySwissDorm.R
 import com.android.mySwissDorm.model.city.City
 import com.android.mySwissDorm.model.map.Location
@@ -168,7 +168,8 @@ fun HomePageScreen(
                           val cityLocation = city.location
                           homePageViewModel.saveLocationToProfile(cityLocation)
                           onSelectLocation(cityLocation)
-                        })
+                        },
+                        uri = uiState.cityImageMap[city])
                     Spacer(modifier = Modifier.height(16.dp))
                   }
                 }
@@ -214,7 +215,7 @@ fun HomePageScreen(
  * @param onClick A callback for when the card is clicked.
  */
 @Composable
-fun CityCard(city: City, onClick: () -> Unit) {
+fun CityCard(city: City, onClick: () -> Unit, uri: Uri? = null) {
   Card(
       modifier =
           Modifier.testTag(HomePageScreenTestTags.getTestTagForCityCard(city.name))
@@ -224,8 +225,8 @@ fun CityCard(city: City, onClick: () -> Unit) {
               .clickable { onClick() },
   ) {
     Box {
-      Image(
-          painter = painterResource(city.imageId),
+      AsyncImage(
+          model = uri,
           contentDescription = city.name,
           contentScale = ContentScale.Crop,
           modifier = Modifier.fillMaxWidth().height(180.dp))


### PR DESCRIPTION
## Summary
This PR resolves the issue #175 where unexpected crashes happened when loading the homepage. The root cause of this issue was that the images were loaded with `painterRessource` and in id retrieved from the cloud.

This id is the result of the corresponding integer given by `R.drawable.<cityNameFile>`, but this result is not invariable, causing crashes when trying to load the image in a different version of the application.

## Solution
The solution proposed in this PR is to actually store the city images in the cloud, and associate each city with the corresponding file name.