### PR TITLE
refactor: move bookmark feature from profile to settings screen

### DIFF
--- a/app/src/androidTest/java/com/android/mySwissDorm/ui/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/java/com/android/mySwissDorm/ui/settings/SettingsScreenTest.kt
@@ -42,13 +42,17 @@ class SettingsScreenTest : FirestoreTest() {
   /** Set content with our explicit VM. */
   private fun setContentWithVm(
       onContributionClick: () -> Unit = {},
-      onProfileClick: () -> Unit = {}
+      onProfileClick: () -> Unit = {},
+      onViewBookmarks: () -> Unit = {}
   ) {
     val vm = makeVm()
     compose.setContent {
       MySwissDormAppTheme {
         SettingsScreen(
-            vm = vm, onContributionClick = onContributionClick, onProfileClick = onProfileClick)
+            vm = vm,
+            onContributionClick = onContributionClick,
+            onProfileClick = onProfileClick,
+            onViewBookmarks = onViewBookmarks)
       }
     }
   }
@@ -268,6 +272,21 @@ class SettingsScreenTest : FirestoreTest() {
 
     val scrollTag = C.SettingsTags.SETTINGS_SCROLL
     val buttonTag = C.SettingsTags.CONTRIBUTIONS_BUTTON
+
+    compose.scrollUntilDisplayed(scrollTag, buttonTag)
+    compose.onNodeWithTag(buttonTag, useUnmergedTree = true).performClick()
+    compose.waitForIdle()
+    assert(clicked)
+  }
+
+  @Test
+  fun bookmarksButton_triggersCallback() = runTest {
+    var clicked = false
+    setContentWithVm(onViewBookmarks = { clicked = true })
+    compose.waitForIdle()
+
+    val scrollTag = C.SettingsTags.SETTINGS_SCROLL
+    val buttonTag = C.SettingsTags.BOOKMARKS_BUTTON
 
     compose.scrollUntilDisplayed(scrollTag, buttonTag)
     compose.onNodeWithTag(buttonTag, useUnmergedTree = true).performClick()

--- a/app/src/main/java/com/android/mySwissDorm/resources/C.kt
+++ b/app/src/main/java/com/android/mySwissDorm/resources/C.kt
@@ -289,6 +289,7 @@ object C {
     const val BLOCKED_CONTACTS_LIST = "BlockedContactsList"
     const val BOTTOM_BAR = "bottom_nav"
     const val CONTRIBUTIONS_BUTTON = "ContributionsButton"
+    const val BOOKMARKS_BUTTON = "BookmarksButton"
 
     fun switch(label: String): String = "SettingSwitch_$label"
   }

--- a/app/src/main/java/com/android/mySwissDorm/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/navigation/AppNavHost.kt
@@ -241,7 +241,7 @@ fun AppNavHost(
               navActions.navigateTo(Screen.ProfileContributions)
             }
           },
-      )
+          onViewBookmarks = { navActions.navigateTo(Screen.BookmarkedListings) })
     }
 
     // --- Secondary destinations ---
@@ -589,8 +589,7 @@ fun AppNavHost(
                       Toast.LENGTH_SHORT)
                   .show()
             },
-            onEditPreferencesClick = { navActions.navigateTo(Screen.EditPreferences) },
-            onViewBookmarks = { navActions.navigateTo(Screen.BookmarkedListings) })
+            onEditPreferencesClick = { navActions.navigateTo(Screen.EditPreferences) })
       }
     }
 

--- a/app/src/main/java/com/android/mySwissDorm/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/profile/ProfileScreen.kt
@@ -58,7 +58,6 @@ fun ProfileScreen(
     onChangeProfilePicture: (Photo) -> Unit,
     onBack: () -> Unit,
     onEditPreferencesClick: () -> Unit,
-    onViewBookmarks: () -> Unit = {},
     viewModel: ProfileScreenViewModel = viewModel()
 ) {
   // Collect VM state (initial ensures preview/first composition has data)
@@ -76,7 +75,6 @@ fun ProfileScreen(
       onLogout = onLogout,
       onChangeProfilePicture = onChangeProfilePicture,
       onBack = onBack,
-      onViewBookmarks = onViewBookmarks,
       onToggleEditing = viewModel::toggleEditing,
       onSave = { viewModel.saveProfile(context) },
       onEditPreferencesClick = onEditPreferencesClick)
@@ -117,7 +115,6 @@ private fun ProfileScreenContent(
     onLogout: () -> Unit,
     onChangeProfilePicture: (Photo) -> Unit,
     onBack: () -> Unit,
-    onViewBookmarks: () -> Unit = {},
     onToggleEditing: () -> Unit,
     onSave: () -> Unit,
     onEditPreferencesClick: () -> Unit
@@ -257,25 +254,6 @@ private fun ProfileScreenContent(
                   modifier = Modifier.fillMaxWidth(),
                   tag = "field_residence",
                   options = state.allResidencies.map { it.name })
-
-              // View bookmarked listings button (only in view mode)
-              if (!state.isEditing) {
-                Button(
-                    onClick = onViewBookmarks,
-                    modifier =
-                        Modifier.fillMaxWidth()
-                            .padding(top = 16.dp)
-                            .height(52.dp)
-                            .clip(RoundedCornerShape(12.dp))
-                            .testTag("profile_bookmarks_button"),
-                    colors =
-                        ButtonDefaults.buttonColors(
-                            containerColor = BackGroundColor, contentColor = MainColor),
-                    border = androidx.compose.foundation.BorderStroke(1.dp, MainColor)) {
-                      Text(
-                          text = stringResource(R.string.profile_view_bookmarks), color = MainColor)
-                    }
-              }
 
               Spacer(Modifier.height(10.dp))
               Button(

--- a/app/src/main/java/com/android/mySwissDorm/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/settings/SettingsScreen.kt
@@ -86,6 +86,7 @@ import com.android.mySwissDorm.ui.theme.rememberDarkModePreference
  * @param isAdmin Whether the current user has admin access. If true, displays Admin section.
  * @param onAdminClick Callback invoked when the admin page button is clicked.
  * @param onContributionClick Callback invoked when the contributions button is clicked.
+ * @param onViewBookmarks Callback invoked when the bookmarks button is clicked.
  * @see SettingsViewModel for state management and user data handling
  * @see SettingsScreenContent for the actual UI implementation
  */
@@ -97,7 +98,8 @@ fun SettingsScreen(
     vm: SettingsViewModel = viewModel(),
     isAdmin: Boolean = false,
     onAdminClick: () -> Unit = {},
-    onContributionClick: () -> Unit = {}
+    onContributionClick: () -> Unit = {},
+    onViewBookmarks: () -> Unit = {}
 ) {
   val ui by vm.uiState.collectAsState()
   vm.setIsGuest()
@@ -116,6 +118,7 @@ fun SettingsScreen(
       onProfileClick = onProfileClick,
       onDeleteAccount = { vm.deleteAccount({ _, _ -> }, context) },
       onContributionClick = onContributionClick,
+      onViewBookmarks = onViewBookmarks,
       onUnblockUser = { uid -> vm.unblockUser(uid, context) },
       navigationActions = navigationActions,
       isAdmin = isAdmin,
@@ -141,6 +144,7 @@ private val previewUiState =
  * @param onProfileClick Callback invoked when the profile button is clicked.
  * @param onDeleteAccount Callback invoked when the delete account button is confirmed.
  * @param onContributionClick Callback invoked when the contributions button is clicked.
+ * @param onViewBookmarks Callback invoked when the bookmarks button is clicked.
  * @param onUnblockUser Callback invoked when a blocked user is unblocked.
  * @param navigationActions Optional [NavigationActions] for bottom bar navigation.
  * @param isAdmin Whether to display the Admin section.
@@ -153,6 +157,7 @@ fun SettingsScreenContent(
     onProfileClick: () -> Unit = {},
     onDeleteAccount: () -> Unit = {},
     onContributionClick: () -> Unit = {},
+    onViewBookmarks: () -> Unit = {},
     onUnblockUser: (String) -> Unit = {},
     navigationActions: NavigationActions? = null,
     isAdmin: Boolean = false,
@@ -307,6 +312,17 @@ fun SettingsScreenContent(
                                   ButtonDefaults.buttonColors(
                                       containerColor = MainColor, contentColor = White)) {
                                 Text(stringResource(R.string.settings_view_contributions))
+                              }
+                          Spacer(Modifier.height(12.dp))
+                          Button(
+                              onClick = onViewBookmarks,
+                              modifier =
+                                  Modifier.fillMaxWidth().testTag(C.SettingsTags.BOOKMARKS_BUTTON),
+                              shape = RoundedCornerShape(16.dp),
+                              colors =
+                                  ButtonDefaults.buttonColors(
+                                      containerColor = MainColor, contentColor = White)) {
+                                Text(stringResource(R.string.profile_view_bookmarks))
                               }
                         }
 


### PR DESCRIPTION
## Refactor: Move Bookmark Feature from Profile to Settings Screen

### Summary
Moved the "View Bookmarked Listings" button from the Profile screen to the Settings screen, placing it in the Account section below the Contributions button. This improves the organization of user features by grouping account-related actions together.

This PR corresponds to the issue https://github.com/orgs/swent25-team-18/projects/3/views/1?pane=issue&itemId=142667580&issue=swent25-team-18%7Cmy-swiss-dorm%7C229

### Changes Made

#### UI Changes
- **ProfileScreen.kt**
  - Removed `onViewBookmarks` parameter from `ProfileScreen` and `ProfileScreenContent` composables
  - Removed the "View Bookmarked Listings" button that was displayed in view mode

- **SettingsScreen.kt**
  - Added `onViewBookmarks` parameter to `SettingsScreen` and `SettingsScreenContent` composables
  - Added "View Bookmarked Listings" button in the Account section, positioned below the Contributions button
  - Updated documentation comments to reflect the new parameter

#### Navigation Changes
- **AppNavHost.kt**
  - Removed `onViewBookmarks` callback from ProfileScreen navigation
  - Added `onViewBookmarks = { navActions.navigateTo(Screen.BookmarkedListings) }` to SettingsScreen navigation

#### Test Infrastructure
- **C.kt**
  - Added `BOOKMARKS_BUTTON` constant to `SettingsTags` for UI testing

- **SettingsScreenTest.kt**
  - Added `bookmarksButton_triggersCallback()` test to verify the bookmark button functionality
  - Updated `setContentWithVm()` helper to accept `onViewBookmarks` parameter

### Testing
- Added new test for bookmark button in SettingsScreen
- Verified no existing tests reference the removed bookmark button from ProfileScreen
- All existing ProfileScreen tests continue to pass without modification

### Impact
- **User Experience**: Bookmarks are now accessible from Settings, grouped with other account management features
- **Code Quality**: Better separation of concerns - profile screen focuses on profile editing, settings screen handles account features
- **No Breaking Changes**: Functionality remains identical, only the location changed

Disclaimer: this pr was done with the help/suggestions of ai
<img width="241" height="388" alt="Screenshot 2025-12-05 at 03 19 53" src="https://github.com/user-attachments/assets/d6d18486-099f-49d0-8f02-9a99a1aebe74" />


