### PR TITLE
fix: Resolves generated build APK

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,6 +34,8 @@
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />


### PR DESCRIPTION
## Summary
This PR resolves the issue where the installation of our application is not shown on the phone. This was due to a non separation of the intent filters in `AndroidManifest.xml`.

The solution to this issue is just to declare an additional filter containing the second filter added in #186.

This closes #230.