### PR TITLE
fix(Listing card Ui): height modification

### DIFF
--- a/app/src/main/java/com/android/mySwissDorm/ui/listing/ListingCard.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/listing/ListingCard.kt
@@ -52,7 +52,7 @@ fun ListingCard(
       shape = RoundedCornerShape(16.dp),
       modifier = Modifier.fillMaxWidth().testTag(C.BrowseCityTags.listingCard(data.listingUid)),
       onClick = { onClick(data) }) {
-        Box(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+        Box(modifier = Modifier.fillMaxWidth()) {
           Row(
               modifier = Modifier.fillMaxWidth().padding(end = if (!isGuest) 48.dp else 0.dp),
               verticalAlignment = Alignment.CenterVertically) {


### PR DESCRIPTION
The box at the left now fills the height of the listing card (box that has the photo and recommended banner if visible).
<img width="389" height="441" alt="image" src="https://github.com/user-attachments/assets/78dc68b7-21ad-4d6a-93a3-b2dc2f3f3244" />
