### PR TITLE
fix: fix residency name not entirely displayed

### DIFF
--- a/app/src/main/java/com/android/mySwissDorm/ui/overview/BrowseCityScreen.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/overview/BrowseCityScreen.kt
@@ -813,21 +813,26 @@ private fun ResidencyCard(data: ResidencyCardUI, onClick: (ResidencyCardUI) -> U
                         modifier = Modifier.fillMaxWidth(),
                         horizontalAlignment = Alignment.Start,
                     ) { // Title, location, and grade
-                      Row(
-                          modifier = Modifier.fillMaxWidth(),
-                          horizontalArrangement = Arrangement.SpaceBetween,
-                          verticalAlignment = Alignment.Top) { // Title + grade
-                            Text( // Title
-                                text = data.title,
-                                style = MaterialTheme.typography.titleMedium,
-                                fontWeight = FontWeight.SemiBold,
-                                textAlign = TextAlign.Start,
-                                color = TextColor,
-                                modifier = Modifier.fillMaxWidth(0.5f),
-                                maxLines = 2,
-                                overflow = TextOverflow.Ellipsis,
-                            )
-                            DisplayGrade(data.meanGrade, 16.dp) // Display the mean grade with stars
+                      Box(modifier = Modifier.fillMaxWidth()) {
+                        // Stars positioned at top-right
+                        Box(modifier = Modifier.align(Alignment.TopEnd)) {
+                          DisplayGrade(data.meanGrade, 16.dp) // Display the mean grade with stars
+                        }
+                        // Title positioned lower, taking available width but leaving space for
+                        // stars
+                        Text( // Title
+                            text = data.title,
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            textAlign = TextAlign.Start,
+                            color = TextColor,
+                            modifier =
+                                Modifier.fillMaxWidth(0.7f)
+                                    .padding(top = 20.dp) // Push title below stars
+                                    .align(Alignment.TopStart),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
                       }
                       Row(verticalAlignment = Alignment.Top) { // Location
                         Icon(


### PR DESCRIPTION
### Fix Residency Name Truncation in Residency Cards

Fixes #198

#### Problem
Residency names like "Cité St-Julien" were being truncated in the residency cards displayed in the Reviews tab of the Browse City screen. The title text was constrained to a single line and positioned at the same height as the star rating, causing longer names to be cut off.

#### Solution
Restructured the layout to separate the star rating and title vertically:
- Star rating (DisplayGrade) remains positioned at the top-right of the card
- Title text is now positioned lower (below the stars) to avoid overlap
- Title displays on a single line with proper ellipsis truncation when needed
- Title uses 70% of available width, leaving appropriate space for the star rating

#### Changes Made
- Modified `ResidencyCard` component in `BrowseCityScreen.kt`
  - Replaced `Row` layout with a `Box` layout for more precise positioning
  - Positioned `DisplayGrade` at `Alignment.TopEnd` to keep stars at top-right
  - Positioned title `Text` at `Alignment.TopStart` with `padding(top = 20.dp)` to place it below the stars
  - Set title to single line display (`maxLines = 1`) with `TextOverflow.Ellipsis`
  - Adjusted title width to 70% of available space for proper spacing

#### Testing
- Verified that long residency names (e.g., "Cité St-Julien", "Salvatorhaus") now display more of the name before truncation
- Confirmed star ratings remain correctly positioned at the top-right
- Ensured no overlap between title and star rating components
- No linter errors introduced

Disclaimer: This pr was done with the help/suggestions of ai

#### Screenshots
Before:
The residency "Cité St-Julien" is not correctly displayed in the application. Here is a screenshot from the version from before of the application :

<img width="429" height="886" alt="519385468-8fd1f5f2-6e72-470b-af24-3a460defed1b" src="https://github.com/user-attachments/assets/3e7be92c-fb00-4d79-94c9-42950d0abe89" />

After:

<img width="309" height="513" alt="Screenshot 2025-12-07 at 19 03 03" src="https://github.com/user-attachments/assets/762a3945-4456-49b8-b726-5c9a51a29740" />

