### PR TITLE
chore(frontend): add private accommodation option to signup

### DIFF
--- a/app/src/main/java/com/android/mySwissDorm/ui/authentification/SignUpScreen.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/authentification/SignUpScreen.kt
@@ -195,6 +195,15 @@ fun SignUpScreen(
                                   residenciesExpanded = false
                                 })
                           }
+                          DropdownMenuItem(
+                              modifier =
+                                  Modifier.testTag(
+                                      C.SanitizedResidencyDropdownTags.PRIVATE_ACCOMMODATION),
+                              text = { Text(stringResource(R.string.private_accommodation)) },
+                              onClick = {
+                                signUpViewModel.updateResidencyName("Private Accommodation")
+                                residenciesExpanded = false
+                              })
                         }
                   }
 


### PR DESCRIPTION
This PR adds the Private Accommodation option to the residency dropdown in the sign up screen. 
This closes #152