### PR TITLE
feat(map listings): Image navigation in listing preview

### DIFF
--- a/app/src/androidTest/java/com/android/mySwissDorm/ui/map/SharedMapTest.kt
+++ b/app/src/androidTest/java/com/android/mySwissDorm/ui/map/SharedMapTest.kt
@@ -5,6 +5,9 @@ import androidx.compose.ui.test.*
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.mySwissDorm.model.map.Location
+import com.android.mySwissDorm.resources.C.SharedMapTags.IMAGE_COUNTER
+import com.android.mySwissDorm.resources.C.SharedMapTags.NEXT_IMAGE
+import com.android.mySwissDorm.resources.C.SharedMapTags.PREVIOUS_IMAGE
 import com.android.mySwissDorm.ui.overview.ListingCardUI
 import org.junit.Rule
 import org.junit.Test
@@ -22,7 +25,19 @@ class SharedMapTest {
           leftBullets = listOf("Studio", "1000.-"),
           rightBullets = listOf("Available"),
           listingUid = "uid1",
-          image = Uri.parse("http://fake.uri/image.jpg"),
+          image = listOf(Uri.parse("http://fake.uri/image.jpg")),
+          location = location)
+  private val listingWithMultipleImages =
+      ListingCardUI(
+          title = "Listing Multiple",
+          leftBullets = listOf("Studio", "1200.-"),
+          rightBullets = listOf("Available"),
+          listingUid = "uid2",
+          image =
+              listOf(
+                  Uri.parse("http://fake.uri/image1.jpg"),
+                  Uri.parse("http://fake.uri/image2.jpg"),
+                  Uri.parse("http://fake.uri/image3.jpg")),
           location = location)
 
   @Test
@@ -93,5 +108,35 @@ class SharedMapTest {
 
     composeTestRule.onNodeWithText("Listing With Image").performClick()
     assert(clickedId == "uid1")
+  }
+
+  @Test
+  fun smallListingCard_singleImage_hidesNavigationArrows() {
+    composeTestRule.setContent {
+      SmallListingPreviewCard(listing = listingWithImage, onClick = {}, onClose = {})
+    }
+    composeTestRule.onNodeWithTag(NEXT_IMAGE).assertDoesNotExist()
+    composeTestRule.onNodeWithTag(PREVIOUS_IMAGE).assertDoesNotExist()
+    composeTestRule.onNodeWithTag(IMAGE_COUNTER).assertDoesNotExist()
+  }
+
+  @Test
+  fun smallListingCard_multipleImages_navigatesCorrectly() {
+    composeTestRule.setContent {
+      SmallListingPreviewCard(listing = listingWithMultipleImages, onClick = {}, onClose = {})
+    }
+    composeTestRule.onNodeWithText("1/3").assertIsDisplayed()
+    composeTestRule.onNodeWithTag(PREVIOUS_IMAGE).assertDoesNotExist()
+    composeTestRule.onNodeWithTag(NEXT_IMAGE).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(NEXT_IMAGE).performClick()
+    composeTestRule.onNodeWithText("2/3").assertIsDisplayed()
+    composeTestRule.onNodeWithTag(PREVIOUS_IMAGE).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(NEXT_IMAGE).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(NEXT_IMAGE).performClick()
+    composeTestRule.onNodeWithText("3/3").assertIsDisplayed()
+    composeTestRule.onNodeWithTag(NEXT_IMAGE).assertDoesNotExist()
+    composeTestRule.onNodeWithTag(PREVIOUS_IMAGE).assertIsDisplayed()
+    composeTestRule.onNodeWithTag(PREVIOUS_IMAGE).performClick()
+    composeTestRule.onNodeWithText("2/3").assertIsDisplayed()
   }
 }

--- a/app/src/main/java/com/android/mySwissDorm/resources/C.kt
+++ b/app/src/main/java/com/android/mySwissDorm/resources/C.kt
@@ -376,4 +376,10 @@ object C {
     const val LAST_UPDATED_TEXT = "offlineBannerLastUpdatedText"
     const val NO_SYNC_TEXT = "offlineBannerNoSyncText"
   }
+
+  object SharedMapTags {
+    const val IMAGE_COUNTER = "imageCounter"
+    const val PREVIOUS_IMAGE = "previousImage"
+    const val NEXT_IMAGE = "nextImage"
+  }
 }

--- a/app/src/main/java/com/android/mySwissDorm/ui/listing/BookmarkedListingsViewModel.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/listing/BookmarkedListingsViewModel.kt
@@ -80,7 +80,7 @@ class BookmarkedListingsViewModel(
             if (listing.imageUrls.isNotEmpty()) {
               try {
                 val photo = photoRepositoryCloud.retrievePhoto(listing.imageUrls.first())
-                listingCardUI = listingCardUI.copy(image = photo.image)
+                listingCardUI = listingCardUI.copy(image = listOf(photo.image))
               } catch (_: NoSuchElementException) {
                 Log.e(
                     "BookmarkedListingsViewModel",

--- a/app/src/main/java/com/android/mySwissDorm/ui/listing/ListingCard.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/listing/ListingCard.kt
@@ -64,7 +64,7 @@ fun ListingCard(
                             .clip(RoundedCornerShape(12.dp))
                             .background(ListingCardColor)) {
                       AsyncImage(
-                          model = data.image,
+                          model = data.image.firstOrNull(),
                           contentDescription = null,
                           modifier = Modifier.fillMaxSize(),
                           contentScale = ContentScale.Crop)

--- a/app/src/main/java/com/android/mySwissDorm/ui/map/SharedMap.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/map/SharedMap.kt
@@ -6,6 +6,7 @@ import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -18,12 +19,15 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.android.mySwissDorm.R
+import com.android.mySwissDorm.resources.C
+import com.android.mySwissDorm.resources.C.SharedMapTags.PREVIOUS_IMAGE
 import com.android.mySwissDorm.ui.overview.ListingCardUI
 import com.android.mySwissDorm.ui.theme.*
 import com.google.android.gms.maps.model.LatLng
@@ -201,6 +205,9 @@ fun SmallListingPreviewCard(
     onClose: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+  var currentImageIndex by remember(listing.listingUid) { mutableIntStateOf(0) }
+  val imageCount = listing.image.size
+  val safeIndex = if (imageCount > 0) currentImageIndex.coerceIn(0, imageCount - 1) else 0
   Card(
       modifier = modifier.clickable { onClick() },
       shape = RoundedCornerShape(16.dp),
@@ -208,14 +215,61 @@ fun SmallListingPreviewCard(
       colors = CardDefaults.cardColors(containerColor = White)) {
         Box {
           Column(modifier = Modifier.fillMaxWidth()) {
-            if (listing.image != null) {
-              AsyncImage(
-                  model = listing.image,
-                  contentDescription = null,
-                  modifier = Modifier.fillMaxWidth().height(200.dp),
-                  contentScale = ContentScale.Crop)
+            if (imageCount > 0) {
+              Box(modifier = Modifier.fillMaxWidth().height(200.dp)) {
+                if (listing.image.isNotEmpty()) {
+                  AsyncImage(
+                      model = listing.image[safeIndex],
+                      contentDescription = null,
+                      modifier = Modifier.fillMaxSize(),
+                      contentScale = ContentScale.Crop)
+                }
+                if (imageCount > 1) {
+                  if (safeIndex > 0) {
+                    IconButton(
+                        onClick = { currentImageIndex-- },
+                        modifier =
+                            Modifier.align(Alignment.CenterStart)
+                                .padding(4.dp)
+                                .background(Dark.copy(alpha = 0.5f), CircleShape)
+                                .size(28.dp)
+                                .testTag(PREVIOUS_IMAGE)) {
+                          Icon(
+                              imageVector = Icons.AutoMirrored.Filled.ArrowBackIos,
+                              contentDescription = "Previous Image",
+                              tint = White,
+                              modifier = Modifier.size(14.dp))
+                        }
+                  }
+                  if (safeIndex < imageCount - 1) {
+                    IconButton(
+                        onClick = { currentImageIndex++ },
+                        modifier =
+                            Modifier.align(Alignment.CenterEnd)
+                                .padding(4.dp)
+                                .background(Dark.copy(alpha = 0.5f), CircleShape)
+                                .size(28.dp)
+                                .testTag(C.SharedMapTags.NEXT_IMAGE)) {
+                          Icon(
+                              imageVector = Icons.AutoMirrored.Filled.ArrowForwardIos,
+                              contentDescription = "Next Image",
+                              tint = White,
+                              modifier = Modifier.size(14.dp))
+                        }
+                  }
+                  Text(
+                      text = "${safeIndex + 1}/$imageCount",
+                      style = MaterialTheme.typography.labelSmall,
+                      color = MainColor,
+                      modifier =
+                          Modifier.align(Alignment.BottomEnd)
+                              .padding(8.dp)
+                              .background(Dark.copy(alpha = 0.6f), RoundedCornerShape(4.dp))
+                              .padding(horizontal = 4.dp, vertical = 2.dp)
+                              .testTag(C.SharedMapTags.IMAGE_COUNTER))
+                }
+              }
             }
-
             Column(modifier = Modifier.padding(12.dp)) {
               Text(
                   text = listing.title,

--- a/app/src/main/java/com/android/mySwissDorm/ui/overview/BrowseCityViewModel.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/overview/BrowseCityViewModel.kt
@@ -48,7 +48,7 @@ data class ListingCardUI(
     val leftBullets: List<String>,
     val rightBullets: List<String>,
     val listingUid: String,
-    val image: Uri? = null,
+    val image: List<Uri> = emptyList(),
     val location: Location,
     val isRecommended: Boolean = false
 )
@@ -316,16 +316,16 @@ class BrowseCityViewModel(
               val recommended = isRecommended(listing)
               var listingCardUI = listing.toCardUI(context, recommended)
               if (listing.imageUrls.isNotEmpty()) {
-                val fileName = listing.imageUrls.first()
-                try {
-                  val photo = photoRepositoryCloud.retrievePhoto(fileName)
-                  listingCardUI = listingCardUI.copy(image = photo.image)
-                  Log.d(
-                      "BrowseCityViewModel",
-                      "Photo $fileName retrieved successfully with uri : ${photo.image}")
-                } catch (_: NoSuchElementException) {
-                  Log.e("BrowseCityViewModel", "Failed to retrieve the photo $fileName")
-                }
+                val loadedImages =
+                    listing.imageUrls.mapNotNull { fileName ->
+                      try {
+                        photoRepositoryCloud.retrievePhoto(fileName).image
+                      } catch (_: NoSuchElementException) {
+                        Log.e("BrowseCityViewModel", "Failed to retrieve the photo $fileName")
+                        null
+                      }
+                    }
+                listingCardUI = listingCardUI.copy(image = loadedImages)
               }
               listingCardUI
             }


### PR DESCRIPTION
Users can now see all images of a listing (if they exist) in the small listing preview on the map. I also added the number of images in a listing so the user can know how navigate more easily.
Plus a few tests for the task.

This PR closes #195 

https://github.com/user-attachments/assets/9e963bbb-e326-40c1-8556-65138ee27205

