### PR TITLE
fix: Home button destination when already in Homepage

### DIFF
--- a/app/src/main/java/com/android/mySwissDorm/ui/navigation/NavigationActions.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/navigation/NavigationActions.kt
@@ -82,12 +82,6 @@ class NavigationActions(
   fun navigateTo(screen: Screen) {
     // For Homepage, delegate to ViewModel to determine destination (MVVM pattern)
     if (screen == Screen.Homepage) {
-      val current = currentRoute()
-      // If we're already on the Homepage, stay there (don't navigate to BrowseOverview)
-      if (current == Screen.Homepage.route) {
-        return
-      }
-
       val scope = coroutineScope
       val viewModel = navigationViewModel
       if (scope != null && viewModel != null) {
@@ -95,9 +89,12 @@ class NavigationActions(
           val destination = viewModel.getHomepageDestination()
           // Switch to main thread for navigation (required by Navigation Component)
           withContext(Dispatchers.Main) {
-            val currentAfterCheck = currentRoute()
+            val current = currentRoute()
+            if (current == Screen.Homepage.route && destination != Screen.Homepage) {
+              return@withContext
+            }
             // Only navigate if we're not already on the destination
-            if (currentAfterCheck != destination.route) {
+            if (current != destination.route) {
               navigateToScreen(destination)
             }
           }


### PR DESCRIPTION
## Summary
There was a problem where when we were in the Homepage screen, and clicked on the home button from the bottom bar, it took us to the BrowseCity screen if we had a location stored in our profile, but that's not the wanted behavior. It should keep the user in the Homepage. This closes #263.

## Implementation
The only thing to add was that when we're already in the Homepage and click on the home button, it doesn't do anything.

## Tests
Added checks for past tests to make them more robust.
Added a test for the new coded behavior, staying in Homepage if we press on home button.

## Note
SonarCube shows a 50% line coverage, but it's in fact only 2 lines added to the code, and the second one can't be directly tested (or will be way to specific as a test). The new behavior though, is tested.