### PR TITLE
fix(language): fix roomtypes were not translated

### DIFF
--- a/app/src/androidTest/java/com/android/mySwissDorm/ui/authentification/SignUpPreferencesScreenTest.kt
+++ b/app/src/androidTest/java/com/android/mySwissDorm/ui/authentification/SignUpPreferencesScreenTest.kt
@@ -1,5 +1,6 @@
 package com.android.mySwissDorm.ui.authentification
 
+import android.content.Context
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
@@ -10,6 +11,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.android.mySwissDorm.model.authentification.AuthRepositoryProvider
 import com.android.mySwissDorm.model.map.LocationRepositoryProvider
@@ -37,6 +39,8 @@ class SignUpPreferencesScreenTest : FirestoreTest() {
 
   private lateinit var viewModel: SignUpViewModel
   private lateinit var fakeCredentialManager: FakeCredentialManager
+
+  private val context = ApplicationProvider.getApplicationContext<Context>()
 
   override fun createRepositories() {}
 
@@ -72,9 +76,12 @@ class SignUpPreferencesScreenTest : FirestoreTest() {
         .performScrollTo()
         .assertIsDisplayed()
         .assertHasClickAction()
-    composeTestRule.onNodeWithText(RoomType.STUDIO.toString()).performScrollTo().assertIsDisplayed()
     composeTestRule
-        .onNodeWithText(RoomType.COLOCATION.toString())
+        .onNodeWithText(RoomType.STUDIO.getName(context))
+        .performScrollTo()
+        .assertIsDisplayed()
+    composeTestRule
+        .onNodeWithText(RoomType.COLOCATION.getName(context))
         .performScrollTo()
         .assertIsDisplayed()
     composeTestRule.onNodeWithTag(SIGN_UP_WITH_PREFERENCES).assertIsDisplayed().assertIsEnabled()
@@ -103,7 +110,7 @@ class SignUpPreferencesScreenTest : FirestoreTest() {
           onSignedUp = {})
     }
 
-    val chip = composeTestRule.onNodeWithText(RoomType.STUDIO.toString())
+    val chip = composeTestRule.onNodeWithText(RoomType.STUDIO.getName(context))
     chip.performScrollTo()
     chip.performClick()
     composeTestRule.waitForIdle()
@@ -267,10 +274,13 @@ class SignUpPreferencesScreenTest : FirestoreTest() {
           onUseCurrentLocationClick = {})
     }
 
-    composeTestRule.onNodeWithText(RoomType.STUDIO.toString()).performScrollTo().assertIsDisplayed()
+    composeTestRule
+        .onNodeWithText(RoomType.STUDIO.getName(context))
+        .performScrollTo()
+        .assertIsDisplayed()
 
     val target = RoomType.COLOCATION
-    composeTestRule.onNodeWithText(target.toString()).performScrollTo().performClick()
+    composeTestRule.onNodeWithText(target.getName(context)).performScrollTo().performClick()
 
     assert(clickedType.value == target)
   }

--- a/app/src/androidTest/java/com/android/mySwissDorm/ui/overview/BrowseCityScreenTest.kt
+++ b/app/src/androidTest/java/com/android/mySwissDorm/ui/overview/BrowseCityScreenTest.kt
@@ -646,7 +646,7 @@ class BrowseCityScreenFirestoreTest : FirestoreTest() {
     vm.uiState.value.listings.items.forEach { listing ->
       assertTrue(
           "All listings should be Studio type",
-          listing.leftBullets.firstOrNull() == RoomType.STUDIO.toString())
+          listing.leftBullets.firstOrNull() == RoomType.STUDIO.getName(context))
     }
   }
 

--- a/app/src/androidTest/java/com/android/mySwissDorm/ui/profile/EditPreferencesScreenTest.kt
+++ b/app/src/androidTest/java/com/android/mySwissDorm/ui/profile/EditPreferencesScreenTest.kt
@@ -1,5 +1,6 @@
 package com.android.mySwissDorm.ui.profile
 
+import android.content.Context
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -34,6 +35,8 @@ class EditPreferencesScreenTest : FirestoreTest() {
 
   private lateinit var viewModel: ProfileScreenViewModel
   private lateinit var uid: String
+
+  private val context = ApplicationProvider.getApplicationContext<Context>()
 
   override fun createRepositories() {}
 
@@ -86,7 +89,7 @@ class EditPreferencesScreenTest : FirestoreTest() {
   fun interactingWithRoomTypes_updatesState() {
     composeTestRule.setContent { EditPreferencesScreen(viewModel = viewModel, onBack = {}) }
     composeTestRule.waitForIdle()
-    val roomType = RoomType.STUDIO.toString()
+    val roomType = RoomType.STUDIO.getName(context)
     composeTestRule.onNodeWithText(roomType).performScrollTo().performClick()
     val currentTypes = viewModel.uiState.value.selectedRoomTypes
     assertTrue("Studio should be selected in VM state", currentTypes.contains(RoomType.STUDIO))
@@ -101,7 +104,10 @@ class EditPreferencesScreenTest : FirestoreTest() {
     }
     composeTestRule.waitForIdle()
     val roomTypeToSelect = RoomType.STUDIO
-    composeTestRule.onNodeWithText(roomTypeToSelect.toString()).performScrollTo().performClick()
+    composeTestRule
+        .onNodeWithText(roomTypeToSelect.getName(context))
+        .performScrollTo()
+        .performClick()
     composeTestRule.onNodeWithTag(C.FilterTestTags.SLIDER_PRICE).performTouchInput { swipeRight() }
     composeTestRule.onNodeWithText("Save Preferences").performClick()
     composeTestRule.waitUntil(timeoutMillis = 5000) { backPressed }

--- a/app/src/androidTest/java/com/android/mySwissDorm/ui/profile/ProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/mySwissDorm/ui/profile/ProfileScreenTest.kt
@@ -583,7 +583,7 @@ class ProfileScreenFirestoreTest : FirestoreTest() {
     compose.setContent { EditPreferencesScreen(viewModel = vm, onBack = {}) }
     compose.waitForIdle()
     compose.onNodeWithTag("price_slider").performTouchInput { swipeRight() }
-    val roomType = RoomType.STUDIO.toString()
+    val roomType = RoomType.STUDIO.getName(context)
     compose.onNodeWithText(roomType).performScrollTo().performClick()
     compose.onNodeWithText("Save Preferences").performClick()
     var success = false

--- a/app/src/main/java/com/android/mySwissDorm/model/rental/RentalListing.kt
+++ b/app/src/main/java/com/android/mySwissDorm/model/rental/RentalListing.kt
@@ -1,5 +1,7 @@
 package com.android.mySwissDorm.model.rental
 
+import android.content.Context
+import com.android.mySwissDorm.R
 import com.android.mySwissDorm.model.map.Location
 import com.google.firebase.Timestamp
 
@@ -42,13 +44,13 @@ data class RentalListing(
     val location: Location
 )
 
-enum class RoomType(val value: String) {
-  STUDIO("Studio"),
-  APARTMENT("Apartment"),
-  COLOCATION("Room in flatshare");
+enum class RoomType(val stringResId: Int) {
+  STUDIO(R.string.studio),
+  APARTMENT(R.string.apartment),
+  COLOCATION(R.string.room_in_flatshare);
 
-  override fun toString(): String {
-    return value
+  fun getName(context: Context): String {
+    return context.getString(stringResId)
   }
 }
 

--- a/app/src/main/java/com/android/mySwissDorm/model/rental/RentalListingRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/mySwissDorm/model/rental/RentalListingRepositoryFirestore.kt
@@ -140,7 +140,7 @@ class RentalListingRepositoryFirestore(
       val postedAt = document.getTimestamp("postedAt") ?: return null
       val roomTypeStr = document.getString("roomType") ?: return null
       val roomType =
-          RoomType.entries.firstOrNull { it.name == roomTypeStr || it.value == roomTypeStr }
+          RoomType.entries.firstOrNull { it.name == roomTypeStr }
               ?: return null // will take the value if its in the num otherwise null for safety
       val pricePerMonth = document.getDouble("pricePerMonth") ?: return null
       val areaInM2 = document.getLong("areaInM2")?.toInt() ?: return null

--- a/app/src/main/java/com/android/mySwissDorm/model/review/ReviewsRepositoryFirestore.kt
+++ b/app/src/main/java/com/android/mySwissDorm/model/review/ReviewsRepositoryFirestore.kt
@@ -267,7 +267,7 @@ class ReviewsRepositoryFirestore(private val db: FirebaseFirestore) : ReviewsRep
       val residencyName = document.getString("residencyName") ?: return null
       val roomTypeString = document.getString("roomType") ?: return null
       val roomType =
-          RoomType.entries.firstOrNull { it.name == roomTypeString || it.value == roomTypeString }
+          RoomType.entries.firstOrNull { it.name == roomTypeString }
               ?: return null // will take the value if its in the num otherwise null for safety
       val pricePerMonth = document.getDouble("pricePerMonth") ?: return null
       val areaInM2 = (document.getDouble("areaInM2") ?: return null).toInt()

--- a/app/src/main/java/com/android/mySwissDorm/ui/SanitizedTextFields.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/SanitizedTextFields.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextRange
@@ -350,10 +351,11 @@ fun HousingTypeDropdown(selected: RoomType?, onSelected: (RoomType) -> Unit, acc
                 ),
         modifier = Modifier.menuAnchor().fillMaxWidth(),
     )
+    val context = LocalContext.current
     ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
       RoomType.entries.forEach { type ->
         DropdownMenuItem(
-            text = { Text(type.toString()) },
+            text = { Text(type.getName(context)) },
             onClick = {
               onSelected(type)
               expanded = false

--- a/app/src/main/java/com/android/mySwissDorm/ui/listing/BookmarkedListingsViewModel.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/listing/BookmarkedListingsViewModel.kt
@@ -166,7 +166,7 @@ private fun RentalListing.toCardUI(context: Context): ListingCardUI {
 
   return ListingCardUI(
       title = title,
-      leftBullets = listOf(roomType.toString(), price, area),
+      leftBullets = listOf(roomType.getName(context), price, area),
       rightBullets = listOf(start, resName),
       listingUid = uid,
       location = location)

--- a/app/src/main/java/com/android/mySwissDorm/ui/listing/ViewListingScreen.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/listing/ViewListingScreen.kt
@@ -348,7 +348,7 @@ fun ViewListingScreen(
 
                 // Bullet section
                 SectionCard(modifier = Modifier.testTag(C.ViewListingTags.BULLETS)) {
-                  BulletRow("${listing.roomType}")
+                  BulletRow(listing.roomType.getName(context))
                   BulletRow(
                       "${listing.pricePerMonth}${stringResource(R.string.view_listing_price_per_month)}")
                   BulletRow("${listing.areaInM2}m²")

--- a/app/src/main/java/com/android/mySwissDorm/ui/overview/BrowseCityScreen.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/overview/BrowseCityScreen.kt
@@ -677,13 +677,14 @@ private fun RoomTypeFilterContent(
     selectedRoomTypes: Set<RoomType>,
     onSelectionChange: (Set<RoomType>) -> Unit
 ) {
+  val context = LocalContext.current
   Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
     RoomType.entries.forEach { roomType ->
       Row(
           modifier = Modifier.fillMaxWidth(),
           verticalAlignment = Alignment.CenterVertically,
           horizontalArrangement = Arrangement.SpaceBetween) {
-            Text(roomType.toString(), color = TextColor)
+            Text(roomType.getName(context), color = TextColor)
             Checkbox(
                 checked = roomType in selectedRoomTypes,
                 onCheckedChange = { checked ->

--- a/app/src/main/java/com/android/mySwissDorm/ui/overview/BrowseCityViewModel.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/overview/BrowseCityViewModel.kt
@@ -584,7 +584,7 @@ private fun RentalListing.toCardUI(context: Context, isRecommended: Boolean): Li
 
   return ListingCardUI(
       title = title,
-      leftBullets = listOf(roomType.toString(), price, area),
+      leftBullets = listOf(roomType.getName(context), price, area),
       rightBullets = listOf(start, resName),
       listingUid = uid,
       location = location,

--- a/app/src/main/java/com/android/mySwissDorm/ui/review/ViewReviewScreen.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/review/ViewReviewScreen.kt
@@ -190,7 +190,7 @@ fun ViewReviewScreen(
 
               // Bullet section
               SectionCard(modifier = Modifier.testTag(C.ViewReviewTags.BULLETS)) {
-                BulletRow("${review.roomType}")
+                BulletRow(review.roomType.getName(context))
                 BulletRow(
                     "${review.pricePerMonth}${stringResource(R.string.view_review_price_per_month)}")
                 BulletRow("${review.areaInM2}m²")

--- a/app/src/main/java/com/android/mySwissDorm/ui/utils/ListingPreferencesContent.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/utils/ListingPreferencesContent.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
@@ -85,6 +86,7 @@ fun ListingPreferencesContent(
     onUseCurrentLocationClick: () -> Unit
 ) {
   val scrollState = rememberScrollState()
+  val context = LocalContext.current
 
   if (showLocationDialog) {
     CustomLocationDialog(
@@ -209,7 +211,7 @@ fun ListingPreferencesContent(
                         FilterChip(
                             selected = isSelected,
                             onClick = { onToggleRoomType(type) },
-                            label = { Text(type.toString()) },
+                            label = { Text(type.getName(context)) },
                             leadingIcon =
                                 if (isSelected) {
                                   { Icon(Icons.Default.Check, contentDescription = null) }

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -67,6 +67,11 @@
     <string name="user">Utilisateur</string>
     <string name="website">Site web</string>
 
+    <!-- RoomType -->
+    <string name="studio">Studio</string>
+    <string name="apartment">Appartement</string>
+    <string name="room_in_flatshare">Chambre en colocation</string>
+
     <!-- AdminPageScreen -->
     <string name="admin_page_admins_only">Réservé aux administrateurs.</string>
     <string name="admin_page_title">Page Administrateur</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -65,6 +65,11 @@
     <string name="user">User</string>
     <string name="website">Website</string>
 
+    <!-- RoomType -->
+    <string name="studio">Studio</string>
+    <string name="apartment">Apartment</string>
+    <string name="room_in_flatshare">Room in flatshare</string>
+
     <!-- AdminPageScreen -->
     <string name="admin_page_admins_only">Admins only.</string>
     <string name="admin_page_title">Admin Page</string>


### PR DESCRIPTION
The roomtypes were not translated, as they had an hardcoded string in the RoomType enum. Changed those hardcoded strings to string resource IDs. 

The `toString` was not usable anymore, because it needed a context (not accessible in the enum) to get the strings defined by the string resources IDs. Replaced it by a `getName` function taking a `Context` as argument.

A lot of changes have been made accordingly in the other files, to use the `getName` function.