### PR TITLE
fix: remove additional space from command in build file

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -49,7 +49,7 @@ jobs:
           MAPS_API_KEY: ${{secrets.MAPS_API_KEY }}
           STREAM_API_KEY: ${{secrets.STREAM_API_KEY}}
           OPENROUTESERVICE_API_KEY: ${{secrets.OPENROUTESERVICE_API_KEY}}
-        run: ./gradlew assembleRelease -PMAPS_API_KEY="$MAPS_API_KEY" -PSTREAM_API_KEY="$STREAM_API_KEY" -POPENROUTESERVICE_API_KEY ="$OPENROUTESERVICE_API_KEY" lint --parallel
+        run: ./gradlew assembleRelease -PMAPS_API_KEY="$MAPS_API_KEY" -PSTREAM_API_KEY="$STREAM_API_KEY" -POPENROUTESERVICE_API_KEY="$OPENROUTESERVICE_API_KEY" lint --parallel
 
       - name: Upload APK
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This PR fixes a problem that made the build fail, since there was an additional space in a command.