### PR TITLE
feat(profile): add university dropdown field and hide dropdown arrows

### DIFF
--- a/app/src/main/java/com/android/mySwissDorm/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/profile/ProfileScreen.kt
@@ -128,6 +128,7 @@ fun ProfileScreen(
  * @param state Immutable UI state from the VM.
  * @param onFirstNameChange Pushes final first name to VM on save.
  * @param onLastNameChange Pushes final last name to VM on save.
+ * @param onUniversityChange Pushes final university to VM on save.
  * @param onLanguageChange Pushes final language to VM on save.
  * @param onResidenceChange Pushes final residence to VM on save.
  * @param onLogout Invoked in view mode by the "LOGOUT" button.
@@ -485,6 +486,8 @@ private fun DropdownField(
             enabled = enabled,
             singleLine = true,
             label = { Text(label, color = Gray) },
+            // Only show trailing dropdown icon when enabled (edit mode) to avoid confusion in view
+            // mode
             trailingIcon =
                 if (enabled) {
                   { ExposedDropdownMenuDefaults.TrailingIcon(expanded) }

--- a/app/src/main/java/com/android/mySwissDorm/ui/profile/ProfileScreenViewModel.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/profile/ProfileScreenViewModel.kt
@@ -39,12 +39,14 @@ import kotlinx.coroutines.launch
  * @property language The user's preferred language (string label shown by the dropdown).
  * @property residence The user's residence label (string from
  *   [com.android.mySwissDorm.model.residency.ResidencyName]).
+ * @property university The user's university name (displayed/edited in the UI).
  * @property isEditing True when the screen is in edit mode (fields enabled, Save button visible).
  * @property isSaving True while a save operation is in progress (use to disable Save/show progress
  *   text).
  * @property errorMsg Optional error message to surface to the UI (e.g., auth or Firestore
  *   failures).
  * @property profilePicture the user's profile picture
+ * @property allUniversities List of all available universities for selection in the UI.
  */
 data class ProfileUiState(
     val firstName: String = "",
@@ -74,7 +76,7 @@ data class ProfileUiState(
  *
  * Responsibilities:
  * - Holds and exposes [ProfileUiState] via [uiState].
- * - Handles user edits (first/last name, language, residence).
+ * - Handles user edits (first/last name, university, language, residence).
  * - Toggles edit/view mode.
  * - Persists changes to Firestore under `profiles/{uid}`.
  *


### PR DESCRIPTION
### Description

Adds an editable university dropdown field to the profile screen and hides dropdown arrows when not in edit mode to improve UX clarity.

### Changes Made

#### University Field Enhancement
- Converted university field from text input to dropdown selection, matching the pattern used for language and residency fields
- University dropdown shows all available universities from the repository
- Dropdown arrow only appears when in edit mode
- Selected university is properly persisted to Firestore through the existing profile save mechanism

#### UX Improvement
- Removed dropdown arrows from Language, Residency, and University fields when not in edit mode
- Prevents user confusion about fields being directly selectable without entering edit mode first

### Technical Details

- Added `allUniversities: List<University>` to `ProfileUiState`
- Updated `ProfileScreenViewModel.init` to load universities alongside residencies from `UniversitiesRepositoryProvider`
- Replaced `EditableTextField` with `DropdownField` component for university field in `ProfileScreen`
- Modified `DropdownField` trailing icon logic to only display when `enabled == true`
- University selection is properly saved through existing `saveProfile()` flow

### Files Modified

- `app/src/main/java/com/android/mySwissDorm/ui/profile/ProfileScreen.kt`
- `app/src/main/java/com/android/mySwissDorm/ui/profile/ProfileScreenViewModel.kt`

### Testing Recommendations

- Verify university dropdown appears and functions correctly in edit mode
- Verify dropdown arrows are hidden in view mode
- Verify university selection saves correctly to database
- Verify university loads correctly when profile screen is opened
