### PR TITLE
fix(ci): update java version to 21 to support firebase-tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: "21"
       - name: Gradle cache
         uses: gradle/actions/setup-gradle@v3
       - name: AVD cache


### PR DESCRIPTION
## Problem
Instrumentation tests were failing in last CI runs, because the latest `firebase-tools` made an update. That was the error we got when trying to run the Firebase emulators on the CI:
`Error: firebase-tools no longer supports Java version before 21. Please install a JDK at version 21 or above to get a compatible runtime.`

## Solution
Upgrade the `java-version` from 17 to 21 for the instrumentation tests part of the CI.
