### PR TITLE
feat: Force portrait mode on the app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,6 +34,7 @@
             android:value="${STREAM_API_KEY}" />
         <activity
             android:name=".MainActivity"
+            android:screenOrientation="portrait"
             android:exported="true"
             android:label="@string/title_activity_main"
             android:theme="@style/Theme.MySwissDormApp">

--- a/app/src/main/java/com/android/mySwissDorm/ui/overview/BrowseCityScreen.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/overview/BrowseCityScreen.kt
@@ -306,6 +306,7 @@ private fun BrowseCityScreenUI(
                   onClick = {
                     val options =
                         ScanOptions().apply {
+                          setOrientationLocked(false)
                           setDesiredBarcodeFormats(ScanOptions.QR_CODE) // QR only
                           setBeepEnabled(true)
                           setPrompt(context.getString(R.string.settings_qr_prompt))

--- a/app/src/main/java/com/android/mySwissDorm/ui/qr/MyQRCaptureActivity.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/qr/MyQRCaptureActivity.kt
@@ -1,5 +1,12 @@
 package com.android.mySwissDorm.ui.qr
 
+import android.content.pm.ActivityInfo
+import android.os.Bundle
 import com.journeyapps.barcodescanner.CaptureActivity
 
-class MyQrCaptureActivity : CaptureActivity()
+class MyQrCaptureActivity : CaptureActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LOCKED
+    super.onCreate(savedInstanceState)
+  }
+}


### PR DESCRIPTION
## Summary
This PR is the result of the investigation related to #248. We decided to keep the application in portrait mode in order to avoid massive changes for unnecessary uses of the app.

The application in landscape mode does not fit very well on a phone hanged horizontally:
<img width="537" height="223" alt="image" src="https://github.com/user-attachments/assets/be07f5a5-5434-48c5-9b00-ed333c67f234" />

Given that this application has been designed for mobile users, I only considered tablet users, and this does not affect them negatively:

<img width="282" height="450" alt="image" src="https://github.com/user-attachments/assets/b304bbe1-8f7d-47e7-9cc2-977405c51cff" />

For the current version of the application, the overall flow is well handled and I have not found any bugs related to the application sizing on both devices.

## QR code
However, the library used to open a QR code scan activity seems to be glitching when entering in portrait mode only. This is why some modifications to keep this mode has been made to this process.