### PR TITLE
fix(ui): ensure RoomType is properly translated in dropdowns

### DIFF
--- a/app/src/main/java/com/android/mySwissDorm/ui/SanitizedTextFields.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/SanitizedTextFields.kt
@@ -330,7 +330,7 @@ fun DescriptionField(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun HousingTypeDropdown(selected: RoomType?, onSelected: (RoomType) -> Unit, accentColor: Color) {
+fun HousingTypeDropdown(selected: String?, onSelected: (RoomType) -> Unit, accentColor: Color) {
   var expanded by remember { mutableStateOf(false) }
   val label = selected.toString()
 

--- a/app/src/main/java/com/android/mySwissDorm/ui/listing/AddListingScreen.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/listing/AddListingScreen.kt
@@ -137,7 +137,7 @@ fun AddListingScreen(
                   modifier = Modifier.testTag(C.AddListingScreenTags.RESIDENCY_DROPDOWN))
 
               HousingTypeDropdown(
-                  selected = ui.housingType,
+                  selected = ui.housingType.getName(context),
                   onSelected = { addListingViewModel.setHousingType(it) },
                   accentColor = MainColor)
 

--- a/app/src/main/java/com/android/mySwissDorm/ui/listing/EditListingScreen.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/listing/EditListingScreen.kt
@@ -189,7 +189,7 @@ fun EditListingScreen(
                   accentColor = MainColor)
 
               HousingTypeDropdown(
-                  selected = ui.housingType,
+                  selected = ui.housingType.getName(context),
                   onSelected = { editListingViewModel.setHousingType(it) },
                   accentColor = MainColor)
 

--- a/app/src/main/java/com/android/mySwissDorm/ui/review/AddReviewScreen.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/review/AddReviewScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -46,6 +47,7 @@ fun AddReviewScreen(
 ) { //
   val reviewUIState by addReviewViewModel.uiState.collectAsState()
   val scrollState = rememberScrollState()
+  val context = LocalContext.current
   if (reviewUIState.showFullScreenImages) {
     FullScreenImageViewer(
         imageUris = reviewUIState.images.map { it.image },
@@ -127,7 +129,7 @@ fun AddReviewScreen(
                   modifier = Modifier.testTag(C.AddReviewTags.RESIDENCY_DROPDOWN).fillMaxWidth())
 
               HousingTypeDropdown(
-                  selected = ui.roomType,
+                  selected = ui.roomType.getName(context),
                   onSelected = { addReviewViewModel.setRoomType(it) },
                   accentColor = MainColor)
 

--- a/app/src/main/java/com/android/mySwissDorm/ui/review/EditReviewScreen.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/review/EditReviewScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -80,6 +81,7 @@ fun EditReviewScreen(
 ) {
   val editReviewUIState by editReviewViewModel.uiState.collectAsState()
   val scrollState = rememberScrollState()
+  val context = LocalContext.current
   var showDeleteConfirm by remember { mutableStateOf(false) }
   if (editReviewUIState.showFullScreenImages) {
     FullScreenImageViewer(
@@ -178,7 +180,7 @@ fun EditReviewScreen(
                   modifier = Modifier.testTag("residencyDropdown").fillMaxWidth())
 
               HousingTypeDropdown(
-                  selected = ui.roomType,
+                  selected = ui.roomType.getName(context),
                   onSelected = { editReviewViewModel.setRoomType(it) },
                   accentColor = MainColor)
 


### PR DESCRIPTION
Fixes an issue where the `RoomType` enum values (Studio, Apartment, etc.) were not correctly translated in some dropdowns when adding/editing a listing/review.

Fix it by modifying `HousingTypeDropdown` in `SanitizedTextFields` and calling in with the `getName` function from `RoomType` enum.

This PR was written with the help of AI.

Closes #281