### PR TITLE
fix: Put the image loading logic in a non-blocking thread

### DIFF
--- a/app/src/main/java/com/android/mySwissDorm/ui/listing/ViewListingViewModel.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/listing/ViewListingViewModel.kt
@@ -31,6 +31,7 @@ import com.android.mySwissDorm.ui.utils.translateTextField
 import com.google.firebase.Timestamp
 import com.google.firebase.auth.FirebaseAuth
 import kotlin.String
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -207,15 +208,12 @@ class ViewListingViewModel(
               false
             }
 
-        photoManager.initialize(listing.imageUrls)
-        val photos = photoManager.photoLoaded
-
         val uiData =
             UIUpdateData(
                 fullNameOfPoster = fullNameOfPoster,
                 isOwner = isOwner,
                 isBlockedByOwner = isBlockedByOwner,
-                photos = photos,
+                photos = emptyList(),
                 isGuest = isGuest,
                 isBookmarked = isBookmarked,
                 poiDistances = emptyList(),
@@ -232,6 +230,11 @@ class ViewListingViewModel(
             Log.e("ViewListingViewModel", "Error calculating POI distances asynchronously", e)
             _uiState.update { it.copy(isLoadingPOIs = false) }
           }
+        }
+        launch(Dispatchers.IO) {
+          photoManager.initialize(listing.imageUrls)
+          val photos = photoManager.photoLoaded
+          _uiState.update { it.copy(images = photos) }
         }
       } catch (e: Exception) {
         Log.e("ViewListingViewModel", "Error loading listing by ID: $listingId", e)

--- a/app/src/main/java/com/android/mySwissDorm/ui/overview/BrowseCityViewModel.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/overview/BrowseCityViewModel.kt
@@ -312,26 +312,35 @@ class BrowseCityViewModel(
         val mapped =
             sorted.map { listing ->
               val recommended = isRecommended(listing)
-              var listingCardUI = listing.toCardUI(context, recommended)
-              if (listing.imageUrls.isNotEmpty()) {
-                val loadedImages =
-                    listing.imageUrls.mapNotNull { fileName ->
-                      try {
-                        photoRepositoryCloud.retrievePhoto(fileName).image
-                      } catch (_: NoSuchElementException) {
-                        Log.e("BrowseCityViewModel", "Failed to retrieve the photo $fileName")
-                        null
-                      }
-                    }
-                listingCardUI = listingCardUI.copy(image = loadedImages)
-              }
-              listingCardUI
+              listing.toCardUI(context, recommended)
             }
 
         _uiState.update {
           it.copy(
               listings = it.listings.copy(loading = false, items = mapped, error = null),
               bookmarkedListingIds = bookmarkedIds)
+        }
+        launch {
+          val listingsUI =
+              sorted.map { listing ->
+                var listingUI = listing.toCardUI(context, isRecommended(listing))
+                if (listing.imageUrls.isNotEmpty()) {
+                  val loadedImage =
+                      listing.imageUrls.first().let { fileName ->
+                        try {
+                          photoRepositoryCloud.retrievePhoto(fileName).image
+                        } catch (_: NoSuchElementException) {
+                          Log.e("BrowseCityViewModel", "Failed to retrieve the photo $fileName")
+                          null
+                        }
+                      }
+                  if (loadedImage != null) {
+                    listingUI = listingUI.copy(image = listOf(loadedImage))
+                  }
+                }
+                listingUI
+              }
+          _uiState.update { it.copy(listings = it.listings.copy(items = listingsUI)) }
         }
       } catch (e: Exception) {
         _uiState.update {

--- a/app/src/main/java/com/android/mySwissDorm/ui/review/EditReviewViewModel.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/review/EditReviewViewModel.kt
@@ -21,9 +21,11 @@ import com.android.mySwissDorm.ui.photo.PhotoManager
 import com.google.firebase.Firebase
 import com.google.firebase.Timestamp
 import com.google.firebase.auth.auth
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 /**
@@ -244,8 +246,6 @@ class EditReviewViewModel(
         // Preserve existing residencies to avoid clearing them
         val currentResidencies = _uiState.value.residencies
 
-        photoManager.initialize(review.imageUrls)
-
         _uiState.value =
             _uiState.value.copy(
                 postedAt = review.postedAt,
@@ -257,9 +257,12 @@ class EditReviewViewModel(
                 roomType = review.roomType,
                 pricePerMonth = review.pricePerMonth.toString(),
                 areaInM2 = review.areaInM2.toString(),
-                images = photoManager.photoLoaded,
                 isAnonymous = review.isAnonymous,
                 ownerName = review.ownerName)
+        launch(Dispatchers.IO) {
+          photoManager.initialize(review.imageUrls)
+          _uiState.update { it.copy(images = photoManager.photoLoaded) }
+        }
         // If residencies haven't been loaded yet, load them now
         if (currentResidencies.isEmpty()) {
           loadResidencies()


### PR DESCRIPTION
## Summary
This PR just put the image retrieving process in a non-blocking thread when retrieving a listing or a review. It does not change the `ViewReviewByResidency` file because we'll remove images from the review cards.

This closes #315.