### PR TITLE
fix : fix requested message sender

### DIFF
--- a/app/src/androidTest/java/com/android/mySwissDorm/ui/chat/ChannelItemTest.kt
+++ b/app/src/androidTest/java/com/android/mySwissDorm/ui/chat/ChannelItemTest.kt
@@ -13,7 +13,6 @@ import com.android.mySwissDorm.model.profile.ProfileRepositoryProvider
 import com.android.mySwissDorm.model.profile.UserInfo
 import com.android.mySwissDorm.ui.theme.MySwissDormAppTheme
 import io.getstream.chat.android.models.Channel
-import io.getstream.chat.android.models.ChannelUserRead
 import io.getstream.chat.android.models.Member
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
@@ -267,28 +266,6 @@ class ChannelItemTest {
 
     compose.waitForIdle()
     assert(retrieved)
-  }
-
-  @Test
-  fun channelItem_doesNotShowUnreadBadge_forOwnMessages_whenLastReadIsNull() {
-    val currentUserId = "user1"
-    val otherUserId = "user2"
-
-    val myMessage = Message(text = "Hello", user = User(id = currentUserId))
-    val channel =
-        Channel(
-            id = "channel1",
-            members = listOf(Member(user = User(id = currentUserId)), Member(user = User(id = otherUserId))),
-            messages = listOf(myMessage),
-            read = listOf(ChannelUserRead(user = User(id = currentUserId), lastRead = null)))
-
-    compose.setContent {
-      MySwissDormAppTheme { ChannelItem(channel = channel, currentUserId = currentUserId, onChannelClick = {}) }
-    }
-
-    // Should not show unread badge "1" for message authored by current user.
-    compose.waitForIdle()
-    compose.onNodeWithText("1").assertDoesNotExist()
   }
 
   @Test

--- a/app/src/main/java/com/android/mySwissDorm/ui/chat/ChannelsScreen.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/chat/ChannelsScreen.kt
@@ -58,6 +58,7 @@ import com.google.firebase.storage.storage
 import io.getstream.chat.android.client.api.models.QueryChannelsRequest
 import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.models.Filters
+import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
 import io.getstream.result.Result
 import java.text.SimpleDateFormat
@@ -579,25 +580,7 @@ internal fun ChannelItem(
   // Unread count - calculate manually from last read position
   // Note: Stream Chat SDK doesn't expose unreadCount directly, so we calculate it
   val currentUserRead = channel.read.find { it.user.id == currentUserId }
-  val unreadCount =
-      if (channel.messages.isEmpty()) {
-        0
-      } else {
-        // Unread should never include messages authored by the current user.
-        val lastReadDate = currentUserRead?.lastRead
-        channel.messages.count { message ->
-          val isNotMine = message.user.id != currentUserId
-          if (!isNotMine) return@count false
-
-          if (lastReadDate == null) {
-            // If we don't know lastRead, treat messages from others as unread.
-            true
-          } else {
-            val createdAt = message.createdAt ?: message.createdLocallyAt
-            createdAt?.after(lastReadDate) == true
-          }
-        }
-      }
+  val unreadCount = computeUnreadCount(channel.messages, currentUserId, currentUserRead?.lastRead)
 
   Row(
       modifier =
@@ -714,6 +697,34 @@ internal fun formatMessageTime(timestamp: Date, context: Context): String {
     days == 1L -> context.getString(R.string.channels_screen_yesterday)
     days < 7 -> context.getString(R.string.channels_screen_days_ago, days)
     else -> SimpleDateFormat("MMM dd", Locale.getDefault()).format(timestamp)
+  }
+}
+
+/**
+ * Computes an "unread" count for a channel.
+ *
+ * Rules:
+ * - Never count messages authored by [currentUserId] as unread (prevents bogus badges like "1" for
+ *   your own sent messages).
+ * - If [lastRead] is null, count all messages from other users as unread.
+ * - Otherwise, count only messages from other users whose timestamp is after [lastRead].
+ */
+internal fun computeUnreadCount(
+    messages: List<Message>,
+    currentUserId: String,
+    lastRead: Date?,
+): Int {
+  if (messages.isEmpty()) return 0
+
+  return messages.count { message ->
+    if (message.user.id == currentUserId) return@count false
+
+    if (lastRead == null) {
+      true
+    } else {
+      val createdAt = message.createdAt ?: message.createdLocallyAt
+      createdAt?.after(lastRead) == true
+    }
   }
 }
 

--- a/app/src/test/java/com/android/mySwissDorm/ui/chat/ChannelsScreenUnreadCountTest.kt
+++ b/app/src/test/java/com/android/mySwissDorm/ui/chat/ChannelsScreenUnreadCountTest.kt
@@ -1,0 +1,78 @@
+package com.android.mySwissDorm.ui.chat
+
+import io.getstream.chat.android.models.Message
+import io.getstream.chat.android.models.User
+import java.util.Date
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ChannelsScreenUnreadCountTest {
+
+  @Test
+  fun computeUnreadCount_returnsZero_whenNoMessages() {
+    assertEquals(
+        0, computeUnreadCount(messages = emptyList(), currentUserId = "me", lastRead = null))
+  }
+
+  @Test
+  fun computeUnreadCount_doesNotCountOwnMessages_whenLastReadNull() {
+    val me = "me"
+    val messages =
+        listOf(
+            Message(text = "mine", user = User(id = me)),
+            Message(text = "mine2", user = User(id = me)),
+        )
+
+    assertEquals(0, computeUnreadCount(messages = messages, currentUserId = me, lastRead = null))
+  }
+
+  @Test
+  fun computeUnreadCount_countsOtherMessages_whenLastReadNull() {
+    val me = "me"
+    val other = "other"
+    val messages =
+        listOf(
+            Message(text = "mine", user = User(id = me)),
+            Message(text = "theirs", user = User(id = other)),
+        )
+
+    assertEquals(1, computeUnreadCount(messages = messages, currentUserId = me, lastRead = null))
+  }
+
+  @Test
+  fun computeUnreadCount_countsOnlyAfterLastRead_fromOthers() {
+    val me = "me"
+    val other = "other"
+
+    val lastRead = Date(1_000)
+    val before = Date(500)
+    val after = Date(1_500)
+
+    val messages =
+        listOf(
+            Message(text = "before", user = User(id = other), createdAt = before),
+            Message(text = "after", user = User(id = other), createdAt = after),
+            Message(text = "mine-after", user = User(id = me), createdAt = after),
+        )
+
+    assertEquals(
+        1, computeUnreadCount(messages = messages, currentUserId = me, lastRead = lastRead))
+  }
+
+  @Test
+  fun computeUnreadCount_usesCreatedLocallyAt_whenCreatedAtMissing() {
+    val me = "me"
+    val other = "other"
+
+    val lastRead = Date(1_000)
+    val after = Date(1_500)
+
+    val messages =
+        listOf(
+            Message(text = "local-after", user = User(id = other), createdLocallyAt = after),
+        )
+
+    assertEquals(
+        1, computeUnreadCount(messages = messages, currentUserId = me, lastRead = lastRead))
+  }
+}

--- a/app/src/test/java/com/android/mySwissDorm/ui/chat/RequestedMessagesViewModelTest.kt
+++ b/app/src/test/java/com/android/mySwissDorm/ui/chat/RequestedMessagesViewModelTest.kt
@@ -141,6 +141,117 @@ class RequestedMessagesViewModelTest {
       }
 
   @Test
+  fun approveMessage_profileFetchFails_usesFallbackNames_andStillCreatesChannel() =
+      runTest(testDispatcher) {
+        val messageId = "msg_fallback_names"
+        val message =
+            RequestedMessage(
+                id = messageId,
+                fromUserId = "senderId",
+                toUserId = "currentUserId",
+                listingId = "l",
+                listingTitle = "t",
+                message = "Hello",
+                status = MessageStatus.PENDING,
+                timestamp = 0L)
+
+        coEvery { requestedMessageRepository.getRequestedMessage(messageId) } returns message
+        coEvery { requestedMessageRepository.getPendingMessagesForUser(any()) } returns emptyList()
+
+        // Force profile lookups to fail so the ViewModel uses "User <prefix>" fallback names.
+        coEvery { profileRepository.getProfile(any()) } throws RuntimeException("no profile")
+
+        viewModel.approveMessage(messageId, context)
+        advanceUntilIdle()
+
+        // Sender connect should use fallback name.
+        coVerify {
+          StreamChatProvider.connectUser(
+              firebaseUserId = "senderId", displayName = "User sende", imageUrl = "")
+        }
+        // Channel still created with the original requested message as the first message.
+        coVerify {
+          StreamChatProvider.createChannel(
+              channelType = "messaging",
+              channelId = null,
+              memberIds = listOf("senderId", "currentUserId"),
+              extraData = mapOf("name" to "Chat"),
+              initialMessageText = "Hello")
+        }
+        // Reconnect receiver attempted with fallback name.
+        coVerify {
+          StreamChatProvider.connectUser(
+              firebaseUserId = "currentUserId", displayName = "User curre", imageUrl = "")
+        }
+      }
+
+  @Test
+  fun approveMessage_senderConnectFails_setsManualChatSuccessMessage() =
+      runTest(testDispatcher) {
+        val messageId = "msg_sender_connect_fail"
+        val message =
+            RequestedMessage(
+                id = messageId,
+                fromUserId = "senderId",
+                toUserId = "currentUserId",
+                listingId = "l",
+                listingTitle = "t",
+                message = "Hello",
+                status = MessageStatus.PENDING,
+                timestamp = 0L)
+
+        coEvery { requestedMessageRepository.getRequestedMessage(messageId) } returns message
+        coEvery { requestedMessageRepository.getPendingMessagesForUser(any()) } returns emptyList()
+
+        val manualChatString = "Manual chat required"
+        every { context.getString(R.string.requested_messages_approved_manual_chat) } returns
+            manualChatString
+
+        // Fail only the sender connect step.
+        coEvery { StreamChatProvider.connectUser("senderId", any(), any()) } throws
+            RuntimeException("connect fail")
+
+        viewModel.approveMessage(messageId, context)
+        advanceUntilIdle()
+
+        assertEquals(manualChatString, viewModel.uiState.value.successMessage)
+      }
+
+  @Test
+  fun approveMessage_disconnectFails_isSwallowed_andChannelStillCreated() =
+      runTest(testDispatcher) {
+        val messageId = "msg_disconnect_fail"
+        val message =
+            RequestedMessage(
+                id = messageId,
+                fromUserId = "senderId",
+                toUserId = "currentUserId",
+                listingId = "l",
+                listingTitle = "t",
+                message = "Hello",
+                status = MessageStatus.PENDING,
+                timestamp = 0L)
+
+        coEvery { requestedMessageRepository.getRequestedMessage(messageId) } returns message
+        coEvery { requestedMessageRepository.getPendingMessagesForUser(any()) } returns emptyList()
+
+        // Make disconnect throw; ViewModel uses runCatching so this should not crash.
+        coEvery { StreamChatProvider.disconnectUser(any()) } throws RuntimeException("disconnect")
+
+        viewModel.approveMessage(messageId, context)
+        advanceUntilIdle()
+
+        coVerify {
+          StreamChatProvider.createChannel(
+              channelType = "messaging",
+              channelId = null,
+              memberIds = listOf("senderId", "currentUserId"),
+              extraData = mapOf("name" to "Chat"),
+              initialMessageText = "Hello")
+        }
+      }
+
+  @Test
   fun rejectMessage_success_deletesMessage() =
       runTest(testDispatcher) {
         // Given
@@ -363,7 +474,8 @@ class RequestedMessagesViewModelTest {
         coEvery { profileRepository.getProfile("currentUserId") } returns myProfile
 
         every { StreamChatProvider.isInitialized() } returns true
-        // Only fail reconnecting the receiver; allow sender connect so channel creation can proceed.
+        // Only fail reconnecting the receiver; allow sender connect so channel creation can
+        // proceed.
         coEvery { StreamChatProvider.connectUser("currentUserId", any(), any()) } throws
             RuntimeException("connect fail")
         // Upsert succeeds


### PR DESCRIPTION
The goal of this pr is to fix these 2 issues :

- When a user contacts the listing's owner, and the owner approves the requested message, in the chats it looks like the owner is the one who sent the requested message.
- When a user contacts the listing's owner, and the owner approves the requested message, in the channels screen the "1" notification pops up on the owner's channel and the other user's channel, even though the user is the one who sent the message

These bugs have been fixed respectively : 

- Since the first message sent between users is the one of the person connected to chat screen, I had to "fake" connect on the other user's account so that it looks like he sent the message, create the channel, then reconnect on the current user's account.
- For the notification, In `ChannelsScreen.kt`, unread count now only counts messages where message.user.id != currentUserId. If lastRead is null, we treat messages from others as unread, but never your own.

Documentation + Tests were made with the help of AI.