### PR TITLE
fix(frontend): fix listing image size on different phones

### DIFF
--- a/app/src/main/java/com/android/mySwissDorm/ui/listing/ListingCard.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/listing/ListingCard.kt
@@ -54,13 +54,17 @@ fun ListingCard(
       onClick = { onClick(data) }) {
         Box(modifier = Modifier.fillMaxWidth()) {
           Row(
-              modifier = Modifier.fillMaxWidth().padding(end = if (!isGuest) 48.dp else 0.dp),
+              modifier =
+                  Modifier.fillMaxWidth()
+                      // Fix the content height so all cards have the same height
+                      .height(140.dp)
+                      .padding(end = if (!isGuest) 48.dp else 0.dp),
               verticalAlignment = Alignment.CenterVertically) {
-                // Image (left) - height matches card height as suggested in PR review
+                // Image (left) - fills the left side vertically within the fixed card height
                 Box(
                     modifier =
-                        Modifier.height(140.dp)
-                            .fillMaxWidth(0.35F)
+                        Modifier.fillMaxHeight()
+                            .weight(0.35f)
                             .clip(RoundedCornerShape(12.dp))
                             .background(ListingCardColor)) {
                       AsyncImage(
@@ -87,7 +91,7 @@ fun ListingCard(
 
                 Spacer(Modifier.width(12.dp))
 
-                Column(modifier = Modifier.weight(1f)) {
+                Column(modifier = Modifier.weight(0.65f).fillMaxHeight()) {
                   Text(
                       text = data.title,
                       style = MaterialTheme.typography.titleMedium,


### PR DESCRIPTION
This PR fixes the issue where the listing image size wouldn't be restricted to the listing card size, and thus would look weird with bigger images/different phones.
I now made the row containing the image have a fixed size, and the image inside it fills the max size.

This PR closes #349 