### PR TITLE
fix(navigation): fix navigation after applying for a listing

### DIFF
--- a/app/src/main/java/com/android/mySwissDorm/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/android/mySwissDorm/ui/navigation/AppNavHost.kt
@@ -490,7 +490,6 @@ fun AppNavHost(
                                   context.getString(R.string.view_listing_message_sent),
                                   Toast.LENGTH_LONG)
                               .show()
-                          navActions.navigateTo(Screen.ListingOverview(listingUid))
                         }
                       }
                     }


### PR DESCRIPTION
This PR changes the navigation after applying for a listing. I removed the navigation to ViewListingScreen after applying since it's not logical to reload the page (it was already made in the UI state).

This PR closes https://github.com/swent25-team-18/my-swiss-dorm/issues/353